### PR TITLE
fix: handle repositories with no branches

### DIFF
--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -116,6 +116,11 @@ export const checkout = gitProcedure
       return await exit(0);
     }
 
+    if (branches.length === 0) {
+      p.log.error("no branches found in the repository");
+      return await exit(1);
+    }
+
     const branch = await p.select({
       message: "select a branch to checkout",
       options: branches.map((branch) => ({

--- a/packages/cli/src/utils/git.ts
+++ b/packages/cli/src/utils/git.ts
@@ -114,7 +114,7 @@ export const checkoutLocalBranch = async (branch: string) => {
 
 export const deleteBranches = async (
   branches: string[],
-  force: boolean = false
+  force: boolean = false,
 ) => {
   try {
     const result = await git.deleteLocalBranches(branches, force);


### PR DESCRIPTION
This pull request introduces a user-facing improvement to the CLI's branch checkout command and a minor code style update in the git utility.

Improvements to CLI error handling:

* [`packages/cli/src/commands/checkout.ts`](diffhunk://#diff-64de340ccf783a1e27fff6f2aa82127c2f95e47d8ceb1edc4292da34ad3f916aR119-R123): Added a check to display an error and exit if no branches are found in the repository during checkout, improving user feedback.

Code style and consistency:

* [`packages/cli/src/utils/git.ts`](diffhunk://#diff-95415d198174a5e05dfa45507d1f540731f1f5e64bd3659aca3c0721dfc2818aL117-R117): Updated the `deleteBranches` function signature to include a trailing comma for consistency with code style guidelines.

Closes #159