### PR TITLE
chore: move config to `XDG_CONFIG_HOME`

### DIFF
--- a/packages/cli/src/utils/storage.ts
+++ b/packages/cli/src/utils/storage.ts
@@ -21,8 +21,8 @@ export type Storage = z.infer<typeof StorageSchema>;
 
 export class StorageManager {
   private static readonly storagePath: string = resolve(
-    join(os.homedir(), ".noto"),
-    "storage.sithi",
+    join(os.homedir(), ".config", "noto"),
+    ".notorc",
   );
 
   private static storage: Storage = {};


### PR DESCRIPTION
This pull request makes a small change to the configuration file path used by the `StorageManager` class. The storage file is now located in the `.config/noto` directory under the user's home directory and renamed to `.notorc` instead of being in `.noto/storage.sithi`.

Closes #157