### PR TITLE
fix: handle cancellation on interactive context prompt

### DIFF
--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -125,7 +125,7 @@ export const noto = authedGitProcedure
           placeholder: "describe the changes",
         });
 
-        if (p.isCancel(context)) {
+        if (p.isCancel(enteredContext)) {
           p.log.error(color.red("nothing changed!"));
           return await exit(1);
         }


### PR DESCRIPTION
This pull request introduces a minor fix to the `noto` CLI command. The change ensures that the cancellation check uses the correct context variable, which improves reliability when handling user input.

* Updated the cancellation check in the `noto` command to use `enteredContext` instead of `context`, preventing potential logic errors when determining if the operation should be cancelled. (`packages/cli/src/commands/noto.ts`)

Closes #166 