### PR TITLE
feat: support for prompt files

### DIFF
--- a/packages/cli/src/ai/index.ts
+++ b/packages/cli/src/ai/index.ts
@@ -10,6 +10,311 @@ import { StorageManager } from "~/utils/storage";
 
 import type { LanguageModelV2Middleware } from "@ai-sdk/provider";
 
+const COMMIT_GENERATOR_PROMPT = dedent`
+# System Instruction for Noto
+
+You are a Git commit message generator for the \`noto\` CLI tool. Your role is to analyze staged code changes and generate clear, single-line commit messages that follow the user's established style.
+
+## Your Purpose
+
+Generate accurate, concise commit messages by analyzing git diffs and following user-provided style guidelines.
+
+## Core Behavior
+
+**Output Format:** Return ONLY a single-line commit message. No explanations, no markdown, no body, no footer.
+
+**Response Style:**
+- Be precise and factual based on the diff
+- Follow the user's custom guidelines exactly
+- Use clear, specific language
+- Stay within 50-72 characters when possible
+
+**Analysis Process:**
+1. Read any user-provided context to understand the intent behind the changes
+2. Examine the git diff to understand what changed technically
+3. Combine user context and diff analysis to get complete understanding
+4. Apply the user's style guidelines from \`.noto/commit-prompt.md\`
+5. Classify the change type (feat, fix, refactor, docs, style, test, chore, etc.)
+6. Generate a commit message that accurately describes both what changed and why
+
+## Input Structure
+
+You will receive:
+\`\`\`
+USER GUIDELINES:
+[Custom style from .noto/commit-prompt.md]
+
+USER CONTEXT (optional):
+[Additional context or description provided by the user about the changes]
+
+GIT DIFF:
+[Staged changes]
+\`\`\`
+
+If user context is provided, use it to better understand the intent and purpose of the changes. Combine this context with your diff analysis to generate a more accurate and meaningful commit message.
+
+## Output Requirements
+
+Return only the commit message text:
+\`\`\`
+type(scope): description
+\`\`\`
+
+Or whatever format matches the user's guidelines. **Must be single-line only.**
+
+## Quality Standards
+
+- Accurately reflect the changes in the diff
+- Incorporate user-provided context when available to capture the "why"
+- Follow user's format, tense, and capitalization preferences
+- Be specific (avoid vague terms like "update" or "change")
+- Use proper grammar
+- Make the git history useful and searchable
+- Balance technical accuracy with user intent
+
+## What NOT to Do
+
+- Don't add explanations or commentary
+- Don't generate multi-line messages
+- Don't make assumptions beyond the visible diff
+- Don't ignore the user's style guidelines
+- Don't use generic or vague descriptions
+
+**Remember:** Your output becomes permanent git history. Generate commit messages that are clear, accurate, and consistent with the user's established patterns.
+`;
+
+const DEFAULT_COMMIT_GUIDELINES = dedent`
+# Commit Message Guidelines
+
+## Format
+Use conventional commits: \`type(scope): description\`
+
+The scope is optional but recommended when changes affect a specific component or area.
+
+## Style Rules
+- **Tense**: Imperative present tense (e.g., "add" not "added" or "adds")
+- **Capitalization**: Lowercase for the first letter of description
+- **Length**: Keep the entire message under 72 characters, ideally around 50
+- **Tone**: Clear, concise, and professional
+
+## Commit Types
+- \`feat\`: New feature or functionality for the user
+- \`fix\`: Bug fix that resolves an issue
+- \`docs\`: Documentation changes only
+- \`style\`: Code style changes (formatting, missing semicolons, etc.) with no logic changes
+- \`refactor\`: Code changes that neither fix bugs nor add features
+- \`perf\`: Performance improvements
+- \`test\`: Adding or updating tests
+- \`build\`: Changes to build system or dependencies (npm, webpack, etc.)
+- \`ci\`: Changes to CI/CD configuration files and scripts
+- \`chore\`: Routine tasks, maintenance, or tooling changes
+- \`revert\`: Revert a previous commit
+
+## Scope Usage
+**Prefer omitting scopes whenever possible.** Only include a scope when it significantly clarifies which part of the codebase is affected.
+
+Use scopes sparingly and only when the change is isolated to a specific area:
+- Component or module names (e.g., \`auth\`, \`api\`, \`ui\`, \`parser\`)
+- Feature areas (e.g., \`login\`, \`checkout\`, \`dashboard\`)
+- File or directory names when appropriate
+
+Omit scope for:
+- Changes that affect the entire project
+- Changes that don't fit a specific area
+- Most commits where the type and description are clear enough
+- When in doubt, leave it out
+
+## Description Patterns
+- Start with a verb in imperative mood (add, update, remove, fix, implement, etc.)
+- Be specific about what changed, not how it changed
+- Focus on the "what" and "why", not the "how"
+- Avoid ending with a period
+- Keep it clear enough that someone can understand the change without reading the code
+
+## Examples
+- \`feat: add OAuth2 authentication support\`
+- \`fix: resolve timeout issue in user endpoint\`
+- \`docs: update installation instructions in README\`
+- \`style: fix indentation and spacing\`
+- \`refactor: simplify data parsing logic\`
+- \`perf: optimize database query performance\`
+- \`test: add unit tests for login validation\`
+- \`build: upgrade webpack to version 5\`
+- \`ci: add automated deployment workflow\`
+- \`chore: update dependencies to latest versions\`
+
+Examples with scope (use only when necessary):
+- \`feat(auth): add biometric authentication\`
+- \`fix(api): handle null response in user service\`
+
+## Breaking Changes
+For breaking changes, add \`!\` after the type/scope:
+- \`feat!: remove deprecated API endpoints\`
+- \`refactor(api)!: change response format to JSON:API spec\`
+
+## Additional Notes
+- If a commit addresses a specific issue, you can reference it in the description (e.g., \`fix: resolve memory leak (fixes #123)\`)
+- Each commit should represent a single logical change
+- Write commits as if completing the sentence: "If applied, this commit will..."`;
+
+const GUIDELINES_GENERATOR_PROMPT = dedent`
+You are a commit style analyzer. Analyze the provided commit history and generate a personalized style guide that will be used to generate future commit messages.
+
+## Task
+
+Analyze the commit messages below and create clear guidelines that capture the user's commit message style and patterns.
+
+## Input Format
+
+You will receive a list of commit messages from the user's git history:
+
+\`\`\`
+COMMIT HISTORY:
+[List of previous commit messages]
+\`\`\`
+
+## Output Format
+
+Generate a markdown document with clear, actionable guidelines. Use this structure:
+
+\`\`\`markdown
+# Commit Message Guidelines
+
+## Format
+[Describe the exact format: conventional commits, custom format, etc.]
+
+## Style Rules
+- **Tense**: [present/past/imperative]
+- **Capitalization**: [first letter uppercase/lowercase/varies]
+- **Length**: [typical character count or "concise"/"detailed"]
+- **Tone**: [technical/casual/formal]
+
+## Commit Types
+[List the types they use with brief descriptions]
+- \`type\`: When to use this type
+
+## Scope Usage
+[If they use scopes, describe the pattern. If not, say "No scopes used"]
+
+## Description Patterns
+[How they write descriptions - specific patterns, keywords, style]
+
+## Examples from History
+[Include 3-5 actual examples from their commits]
+\`\`\`
+
+## Analysis Guidelines
+
+**IMPORTANT**: Ignore merge commits when analyzing style. Skip any commits that:
+- Start with "Merge pull request"
+- Start with "Merge branch"
+- Start with "Merge remote-tracking branch"
+- Contain "Merge" as the primary action
+
+Focus only on regular commits (features, fixes, refactors, etc.) for style analysis.
+
+When analyzing commits, look for:
+
+1. **Structure Patterns**:
+   - Do they follow conventional commits? (type: description or type(scope): description)
+   - Is there a consistent format?
+   - Any special characters or prefixes?
+
+2. **Commit Types**:
+   - What types do they use? (feat, fix, docs, refactor, style, test, chore, etc.)
+   - Are types consistent or mixed?
+   - Any custom types?
+
+3. **Scope Patterns**:
+   - Do they use scopes in parentheses?
+   - What scopes appear frequently?
+   - Are scopes specific (file/component names) or general (area names)?
+
+4. **Writing Style**:
+   - Present tense ("add feature") vs past tense ("added feature") vs imperative ("add feature")
+   - First letter capitalized or lowercase?
+   - Typical length - short and concise or longer and detailed?
+   - Technical terminology or simple language?
+
+5. **Common Patterns**:
+   - Repeated keywords or phrases
+   - How they describe features vs fixes vs refactors
+   - Any emoji usage?
+   - Any ticket/issue references?
+
+## Quality Requirements
+
+The generated guidelines must be:
+- ✓ **Clear and specific** - no vague statements
+- ✓ **Actionable** - easy to follow when generating new commits
+- ✓ **Accurate** - truly reflect the user's style
+- ✓ **Concise** - keep it under 300 words
+- ✓ **Consistent** - don't contradict yourself
+
+## Special Cases
+
+**If commits are inconsistent**: Choose the most frequent pattern and note: "Style varies, but most commonly uses [pattern]"
+
+**If very few commits after filtering merges**: Note: "Limited commit history available. Using conventional commits as base with observed patterns."
+
+**If only merge commits exist**: Generate standard conventional commits guidelines and note: "No regular commits found in history. Using conventional commits format."
+
+**If commits are very simple**: That's fine! Note: "Prefers simple, straightforward commit messages"
+
+**If no clear pattern**: Generate sensible conventional commit guidelines with a note: "No strong pattern detected. Recommending conventional commits format."
+
+## Example Analysis
+
+Given these commits:
+\`\`\`
+feat(auth): add OAuth2 login support
+fix(api): resolve timeout issue in user endpoint
+refactor: simplify database connection logic
+docs: update README with setup instructions
+feat(ui): implement dark mode toggle
+\`\`\`
+
+Generate guidelines like:
+\`\`\`markdown
+# Commit Message Guidelines
+
+## Format
+Use conventional commits: \`type(scope): description\`
+
+## Style Rules
+- **Tense**: Imperative/present ("add", "fix", "implement")
+- **Capitalization**: Lowercase first letter
+- **Length**: Concise, 40-60 characters
+- **Tone**: Technical and specific
+
+## Commit Types
+- \`feat\`: New features or capabilities
+- \`fix\`: Bug fixes and issue resolutions
+- \`refactor\`: Code improvements without new features
+- \`docs\`: Documentation updates
+
+## Scope Usage
+Use specific component/area names in parentheses (auth, api, ui). Omit scope for general changes like refactoring.
+
+## Description Patterns
+Start with action verb (add, implement, resolve, update, simplify). Be specific about what changed. Reference the component or feature affected.
+
+## Examples from History
+- feat(auth): add OAuth2 login support
+- fix(api): resolve timeout issue in user endpoint
+- refactor: simplify database connection logic
+\`\`\`
+
+## Important Notes
+
+- Focus on patterns, not on individual commit content
+- Generate guidelines that will work for future commits, not just explain past ones
+- Keep it practical and easy to follow
+- The output will be stored as \`.noto/commit-prompt.md\` and used by an AI to generate commits
+
+Generate the markdown guidelines now based on the commit history provided.
+`;
+
 const cacheMiddleware: LanguageModelV2Middleware = {
   wrapGenerate: async ({ doGenerate, params }) => {
     const key = hashString(JSON.stringify(params));
@@ -37,7 +342,7 @@ const cacheMiddleware: LanguageModelV2Middleware = {
 
 export const generateCommitMessage = async (
   diff: string,
-  type?: string,
+  prompt?: string,
   context?: string,
   forceCache: boolean = false,
 ) => {
@@ -56,66 +361,46 @@ export const generateCommitMessage = async (
     messages: [
       {
         role: "system",
-        content: dedent`
-        ## Persona
-        You are a highly specialized AI assistant engineered for generating precise, standards-compliant Git commit messages. Your function is to serve as an automated tool ensuring consistency and clarity in version control history, adhering strictly to predefined formatting rules optimized for software development workflows.
-
-        ## Core Objective
-        Your objective is to meticulously analyze provided code changes (diffs) and synthesize a Git commit message that strictly conforms to the specified output requirements. The focus is on accuracy, conciseness, and unwavering adherence to the format.
-
-        ## Input Specification
-        The input provided by the user will be structured as follows:
-
-        1.  **Optional Type Override:** A line indicating the desired commit type, formatted as:
-            \`USER_SPECIFIED_TYPE: <value>\`
-            *   The \`<value>\` will either be one of the valid types (\`chore\`, \`feat\`, \`fix\`, \`docs\`, \`refactor\`, \`perf\`, \`test\) or the special keyword \`[none]\` if the user does not wish to force a specific type.
-        2.  **Optional User Context:** A section providing supplementary information about the changes, formatted as:
-            \`USER_PROVIDED_CONTEXT:\`
-            \`{context_placeholder or [none]}\`
-            *   This context (e.g., issue details, goal description) is optional. If provided, use it to better understand the *purpose* and *intent* behind the code changes. If not provided, the value will be \`[none]\`.
-        3.  **Diff Content:** The raw diff output, typically generated by \`git diff --staged\`, encapsulated within triple backticks.
-
-        **You must parse the \`USER_SPECIFIED_TYPE:\` and \`USER_PROVIDED_CONTEXT:\` inputs before analyzing the diff.**
-          
-        ## Output Specification & Constraints (Mandatory Adherence)
-        Adherence to the following specifications is mandatory and non-negotiable. Any deviation constitutes an incorrect output.
-
-        1.  **Commit Message Format:**
-            *   The output MUST strictly follow the single-line format: \`<type>: <description>\`
-            *   A single colon (\`:\`) followed by a single space MUST separate the \`<type>\` and \`<description>\`.
-            *   Scopes within the type (e.g., \`feat(api):\`) are explicitly disallowed.
-            *   Message bodies and footers are explicitly disallowed. The output MUST be exactly one line.
-
-        2.  **Type (\`<type>\`) - Determination Logic:**
-            *   **Priority 1: User-Specified Type:** Check the value provided on the \`USER_SPECIFIED_TYPE:\` line. If this value is exactly one of \`chore\`, \`feat\`, \`fix\`, \`docs\`, \`refactor\`, \`perf\`, \`test\`, then you **MUST** use this user-specified type.
-            *   **Priority 2: Diff & Context Analysis (Default Behavior):** If the value on the \`USER_SPECIFIED_TYPE:\` line is \`[none]\` or invalid, you **MUST** select the \`<type>\` exclusively from the predefined vocabulary (\`chore\`, \`feat\`, \`fix\`, \`docs\`, \`refactor\`, \`perf\`, \`test\`). Base your selection on your analysis of the diff, **informed by the \`USER_PROVIDED_CONTEXT\`** if available, to accurately reflect the primary semantic purpose of the changes.
-
-        3.  **Description (\`<description>\`):**
-            *   **Tense:** MUST employ the imperative, present tense (e.g.,\`add\`, \`fix\`, \`update\`, \`implement\`, \`refactor\`, \`remove\`).
-            *   **Content:** Must succinctly convey the core semantic change introduced by the diff.
-                *   **Leverage Context:** If \`USER_PROVIDED_CONTEXT\` is available and not \`[none]\`, use it to **refine the description**, ensuring it reflects the *intent* and *purpose* behind the changes, while still accurately summarizing *what* was changed in the diff.
-                *   **Focus:** Prioritize the most significant aspects of the change.
-            *   **File Name Reference:** Inclusion of file names should be exceptional, reserved only for renaming operations or when essential for disambiguating the change's primary focus.
-            *   **Case Sensitivity:** The entire output string, encompassing both \`<type>\` and \`<description>\`, MUST be rendered in lowercase.
-            *   **Punctuation:** The description MUST NOT conclude with any terminal punctuation (e.g., no period/full stop).
-            *   **Length Constraint:** The total character count of the generated commit message line MUST NOT exceed 72 characters. **The description must be concise enough to fit within this limit alongside the chosen type.**`,
+        content: COMMIT_GENERATOR_PROMPT,
       },
       {
         role: "user",
         content: dedent`
-        \`\`\`text
-        USER_SPECIFIED_TYPE: ${type ?? "[none]"}
+        USER GUIDELINES:
+        ${prompt ?? DEFAULT_COMMIT_GUIDELINES}
+        ${context ? `\nUSER CONTEXT:\n${context}` : ""}
 
-        USER_PROVIDED_CONTEXT:
-        ${context ?? "[none]"}
-        \`\`\`
-
-        \`\`\`diff
+        GIT DIFF:
         ${diff}
-        \`\`\``,
+      `,
       },
     ],
   });
 
   return object.message.trim();
+};
+
+export const generateCommitGuidelines = async (commits: string[]) => {
+  const model = await getModel();
+
+  const { object } = await generateObject({
+    model,
+    schema: z.object({
+      prompt: z.string(),
+    }),
+    messages: [
+      {
+        role: "system",
+        content: GUIDELINES_GENERATOR_PROMPT,
+      },
+      {
+        role: "user",
+        content: dedent`
+        COMMIT HISTORY:
+        ${commits.join("\n")}`,
+      },
+    ],
+  });
+
+  return object.prompt.trim();
 };

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,11 +1,13 @@
 import { checkout } from "~/commands/checkout";
 import { config } from "~/commands/config";
 import { prev } from "~/commands/prev";
-import { noto } from "./noto";
+import { init } from "~/commands/init";
+import { noto } from "~/commands/noto";
 
 export const commands = {
   checkout,
   config,
   prev,
+  init,
   noto,
 };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,94 @@
+import fs from "node:fs/promises";
+
+import { z } from "trpc-cli";
+
+import * as p from "@clack/prompts";
+import color from "picocolors";
+
+import dedent from "dedent";
+
+import { gitProcedure } from "~/trpc";
+
+import { getPromptFile } from "~/utils/prompt";
+import { exit } from "~/utils/process";
+import { getGitRoot } from "~/utils/git";
+
+export const init = gitProcedure
+  .meta({
+    description: "initialize noto in the repository",
+  })
+  .input(
+    z.object({
+      root: z.boolean().meta({
+        description: "create the prompt file in the git root",
+      }),
+      generate: z.boolean().meta({
+        description: "generate a prompt file based on existing commits",
+      }),
+    }),
+  )
+  .mutation(async (opts) => {
+    const { input } = opts;
+
+    const root = await getGitRoot();
+
+    let promptFile = root;
+    const cwd = process.cwd();
+
+    const existingPromptFile = await getPromptFile();
+
+    let prompt: string;
+
+    if (existingPromptFile) {
+      if (!existingPromptFile.startsWith(cwd)) {
+        p.log.warn(
+          dedent`${color.yellow("a prompt file already exists!")}
+                    ${color.gray(existingPromptFile)}`,
+        );
+
+        const shouldContinue = await p.confirm({
+          message: "do you want to create in the current directory instead?",
+          initialValue: true,
+        });
+
+        if (p.isCancel(shouldContinue) || !shouldContinue) {
+          p.log.error("aborted");
+          return await exit(1);
+        }
+
+        promptFile = cwd;
+      } else {
+        p.log.error(
+          dedent`${color.red("a prompt file already exists.")}
+                    ${color.gray(existingPromptFile)}`,
+        );
+        return await exit(1);
+      }
+    }
+
+    if (root !== cwd && !input.root) {
+      const shouldUseRoot = await p.confirm({
+        message: "do you want to create the prompt file in the git root?",
+        initialValue: true,
+      });
+
+      if (p.isCancel(shouldUseRoot)) {
+        p.log.error("aborted");
+        return await exit(1);
+      }
+
+      if (!shouldUseRoot) promptFile = cwd;
+    }
+
+    // todo: generate prompt based on existing commits
+
+    try {
+      const dir = `${promptFile}/.noto`;
+      await fs.mkdir(dir, { recursive: true });
+
+      const filePath = `${dir}/commit-prompt.md`;
+      await fs.writeFile(filePath, "noto", "utf-8");
+    } catch {
+      p.log.error(color.red("failed to create the prompt file!"));
+    }
+  });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -11,7 +11,14 @@ import { gitProcedure } from "~/trpc";
 
 import { getPromptFile } from "~/utils/prompt";
 import { exit } from "~/utils/process";
-import { getGitRoot } from "~/utils/git";
+import { getCommits, getGitRoot } from "~/utils/git";
+import { generateCommitGuidelines } from "~/ai";
+
+const EMPTY_TEMPLATE = dedent`
+  # Commit Message Guidelines
+  
+  # Add your custom guidelines here.
+  # When no guidelines are present, noto will use conventional commits format by default.`;
 
 export const init = gitProcedure
   .meta({
@@ -37,7 +44,7 @@ export const init = gitProcedure
 
     const existingPromptFile = await getPromptFile();
 
-    let prompt: string;
+    let prompt: string | null = null;
 
     if (existingPromptFile) {
       if (!existingPromptFile.startsWith(cwd)) {
@@ -80,14 +87,52 @@ export const init = gitProcedure
       if (!shouldUseRoot) promptFile = cwd;
     }
 
-    // todo: generate prompt based on existing commits
+    const commits = await getCommits();
+    let generate = input.generate;
+
+    if (generate) {
+      if (!commits || commits.length < 5) {
+        p.log.error(
+          dedent`${color.red("not enough commits to generate a prompt file.")}
+                    ${color.gray("at least 5 commits are required.")}`,
+        );
+        return await exit(1);
+      }
+    } else if (commits && commits.length >= 5) {
+      const shouldGenerate = await p.confirm({
+        message:
+          "do you want to generate a prompt file based on existing commits?",
+        initialValue: true,
+      });
+
+      if (p.isCancel(shouldGenerate)) {
+        p.log.error("aborted");
+        return await exit(1);
+      }
+
+      generate = shouldGenerate;
+    }
+
+    const spin = p.spinner();
+
+    if (commits && generate) {
+      spin.start("generating commit message guidelines");
+      prompt = await generateCommitGuidelines(commits);
+      spin.stop(color.green("generated commit message guidelines!"));
+    } else {
+      prompt = EMPTY_TEMPLATE;
+    }
 
     try {
       const dir = `${promptFile}/.noto`;
       await fs.mkdir(dir, { recursive: true });
 
       const filePath = `${dir}/commit-prompt.md`;
-      await fs.writeFile(filePath, "noto", "utf-8");
+      await fs.writeFile(filePath, prompt, "utf-8");
+
+      p.log.success(dedent`${color.green("prompt file created!")}
+                        ${color.gray(filePath)}`);
+      return await exit(0);
     } catch {
       p.log.error(color.red("failed to create the prompt file!"));
     }

--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -126,7 +126,7 @@ export const noto = authedGitProcedure
           placeholder: "describe the changes",
         });
 
-        if (p.isCancel(context)) {
+        if (p.isCancel(enteredContext)) {
           p.log.error(color.red("nothing changed!"));
           return await exit(1);
         }

--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -35,6 +35,7 @@ export const noto = authedGitProcedure
     description: "generate a commit message",
     default: true,
     diffRequired: true,
+    promptRequired: true,
   })
   .input(
     z.object({

--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -25,11 +25,6 @@ const availableTypes = [
   "test",
 ];
 
-const commitTypeOptions = availableTypes.map((type) => ({
-  label: type,
-  value: type,
-}));
-
 export const noto = authedGitProcedure
   .meta({
     description: "generate a commit message",
@@ -39,10 +34,6 @@ export const noto = authedGitProcedure
   })
   .input(
     z.object({
-      type: z.string().or(z.boolean()).meta({
-        description: "generate commit message based on type",
-        alias: "t",
-      }),
       message: z.string().or(z.boolean()).meta({
         description: "provide context for commit message",
         alias: "m",
@@ -98,25 +89,6 @@ export const noto = authedGitProcedure
         return await exit(0);
       }
 
-      let type = input.type;
-
-      if (
-        (typeof type === "string" && !availableTypes.includes(type)) ||
-        (typeof type === "boolean" && type === true)
-      ) {
-        const selectedType = await p.select({
-          message: "select the type of commit message",
-          options: commitTypeOptions,
-        });
-
-        if (p.isCancel(type)) {
-          p.log.error(color.red("nothing selected!"));
-          return await exit(1);
-        }
-
-        type = selectedType as string;
-      }
-
       let context = input.message;
       if (typeof context === "string") {
         context = context.trim();
@@ -141,7 +113,7 @@ export const noto = authedGitProcedure
       if (!(await isFirstCommit())) {
         message = await generateCommitMessage(
           ctx.git.diff as string,
-          type as string,
+          ctx.noto.prompt as string,
           typeof context === "string" ? context : undefined,
           input.force,
         );

--- a/packages/cli/src/trpc.ts
+++ b/packages/cli/src/trpc.ts
@@ -7,9 +7,9 @@ import color from "picocolors";
 
 import dedent from "dedent";
 
-import { getGitRoot, getStagedDiff, isGitRepository } from "~/utils/git";
+import { getStagedDiff, isGitRepository } from "~/utils/git";
 import { StorageManager } from "~/utils/storage";
-import { findUp } from "~/utils/fs";
+import { getPromptFile } from "~/utils/prompt";
 import { exit } from "~/utils/process";
 
 import type { TrpcCliMeta } from "trpc-cli";
@@ -73,11 +73,7 @@ export const gitMiddleware = t.middleware(async (opts) => {
   let prompt: string | null = null;
 
   if (meta?.promptRequired) {
-    const root = await getGitRoot();
-    const promptPath = await findUp(".noto/commit-prompt.md", {
-      stopAt: root || process.cwd(),
-      type: "file",
-    });
+    const promptPath = await getPromptFile();
 
     if (promptPath) {
       try {

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -22,6 +22,7 @@ export async function findUp(name: string, options: FindUpOptions = {}) {
     try {
       const stats = await fs.stat(filePath);
       if (
+        options.type === undefined ||
         (options.type === "file" && stats.isFile()) ||
         (options.type === "directory" && stats.isDirectory())
       )

--- a/packages/cli/src/utils/fs.ts
+++ b/packages/cli/src/utils/fs.ts
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toPath = (urlOrPath: string | URL) =>
+  urlOrPath instanceof URL ? fileURLToPath(urlOrPath) : urlOrPath;
+
+export interface FindUpOptions {
+  cwd?: string | URL;
+  type?: "file" | "directory";
+  stopAt?: string | URL;
+}
+
+export async function findUp(name: string, options: FindUpOptions = {}) {
+  let directory = path.resolve(toPath(options.cwd ?? ""));
+  const { root } = path.parse(directory);
+  options.stopAt = path.resolve(toPath(options.stopAt ?? root));
+  const isAbsoluteName = path.isAbsolute(name);
+
+  while (directory) {
+    const filePath = isAbsoluteName ? name : path.join(directory, name);
+    try {
+      const stats = await fs.stat(filePath);
+      if (
+        (options.type === "file" && stats.isFile()) ||
+        (options.type === "directory" && stats.isDirectory())
+      )
+        return filePath;
+    } catch {}
+
+    if (directory === options.stopAt || directory === root) break;
+
+    directory = path.dirname(directory);
+  }
+}

--- a/packages/cli/src/utils/git.ts
+++ b/packages/cli/src/utils/git.ts
@@ -8,6 +8,14 @@ export const isGitRepository = async () => {
   return git.checkIsRepo();
 };
 
+export const getGitRoot = async () => {
+  try {
+    return await git.revparse(["--show-toplevel"]);
+  } catch {
+    return null;
+  }
+};
+
 export const getCommitCount = async () => {
   try {
     const count = await git.raw(["rev-list", "--all", "--count"]);
@@ -107,27 +115,6 @@ export const checkoutLocalBranch = async (branch: string) => {
   try {
     await git.checkoutLocalBranch(branch);
     return true;
-  } catch {
-    return false;
-  }
-};
-
-export const deleteBranches = async (
-  branches: string[],
-  force: boolean = false,
-) => {
-  try {
-    const result = await git.deleteLocalBranches(branches, force);
-    return result.success;
-  } catch {
-    return false;
-  }
-};
-
-export const pull = async (remote?: string, branch?: string) => {
-  try {
-    const result = await git.pull();
-    return result.summary.changes;
   } catch {
     return false;
   }

--- a/packages/cli/src/utils/git.ts
+++ b/packages/cli/src/utils/git.ts
@@ -34,6 +34,15 @@ export const isFirstCommit = async () => {
   return count === 0;
 };
 
+export const getCommits = async (limit: number = 10) => {
+  try {
+    const log = await git.log({ maxCount: limit });
+    return log.all.map((c) => c.message);
+  } catch {
+    return null;
+  }
+};
+
 export const getBranch = async () => {
   try {
     return git.raw(["rev-parse", "--abbrev-ref", "HEAD"]);

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -1,0 +1,10 @@
+import { getGitRoot } from "~/utils/git";
+import { findUp } from "~/utils/fs";
+
+export const getPromptFile = async () => {
+  const root = await getGitRoot();
+  return await findUp(".noto/commit-prompt", {
+    stopAt: root || process.cwd(),
+    type: "file",
+  });
+};

--- a/packages/cli/src/utils/prompt.ts
+++ b/packages/cli/src/utils/prompt.ts
@@ -3,7 +3,7 @@ import { findUp } from "~/utils/fs";
 
 export const getPromptFile = async () => {
   const root = await getGitRoot();
-  return await findUp(".noto/commit-prompt", {
+  return await findUp(".noto/commit-prompt.md", {
     stopAt: root || process.cwd(),
     type: "file",
   });


### PR DESCRIPTION
This pull request introduces major improvements to the commit message generation workflow in the `noto` CLI tool. The changes focus on making commit messages more customizable and user-centric by allowing guideline-driven generation, adding an initialization command for prompt files, and improving the overall developer experience. Key updates include support for user-defined commit message guidelines, a new `init` command to bootstrap guideline files, and a refactor of the commit message generation logic to use these guidelines.

### Commit Message Generation & Guidelines

* Added support for user-defined commit message guidelines in `generateCommitMessage`, allowing commit messages to follow custom formats and styles from `.noto/commit-prompt.md`. The system prompt and user prompt structure were refactored to support this, replacing the previous rigid format and type selection logic. [[1]](diffhunk://#diff-4b910ffcd987f22497dbb81678306363d5228de70ef9c3584472296923ebeb7aR13-R317) [[2]](diffhunk://#diff-4b910ffcd987f22497dbb81678306363d5228de70ef9c3584472296923ebeb7aL40-R345) [[3]](diffhunk://#diff-4b910ffcd987f22497dbb81678306363d5228de70ef9c3584472296923ebeb7aL59-R406) [[4]](diffhunk://#diff-74a0bd6e9f025d8e97f64e4ae085e58c1fc45315377c6719da88d9fd38d2bd38L143-R116)
* Implemented `generateCommitGuidelines`, an AI-powered function that analyzes existing commit history and generates a markdown guidelines file to be used for future commit message generation.

### CLI Command Enhancements

* Added a new `init` command (`packages/cli/src/commands/init.ts`) that initializes a `.noto/commit-prompt.md` file in the repository, either as a blank template or by generating guidelines from commit history if enough commits exist. This helps teams quickly bootstrap custom commit message rules. [[1]](diffhunk://#diff-243d59e62894664d54782df80ecdae3c7fa21dfd1b5fb1cb6f662fd0f19b7bf1R1-R139) [[2]](diffhunk://#diff-d242a4016a55f061eef16969e02d6b5f1c4395de9bfdf003c130dbd4f798d29dL4-R11)
* Updated the command registration to include the new `init` command and refactored imports for consistency.

### User Experience Improvements

* Removed the commit type selection prompt from the `noto` command, streamlining the workflow so commit messages are generated based on guidelines and context rather than manual type selection. [[1]](diffhunk://#diff-74a0bd6e9f025d8e97f64e4ae085e58c1fc45315377c6719da88d9fd38d2bd38L28-L44) [[2]](diffhunk://#diff-74a0bd6e9f025d8e97f64e4ae085e58c1fc45315377c6719da88d9fd38d2bd38L100-L118)
* Improved context input handling to ensure user descriptions are properly captured and validated during commit message generation.

### Miscellaneous

* Added missing imports and improved file organization for better maintainability.