### PR TITLE
chore: use `authedGitProcedure` for init command

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -7,7 +7,7 @@ import color from "picocolors";
 
 import dedent from "dedent";
 
-import { gitProcedure } from "~/trpc";
+import { authedGitProcedure } from "~/trpc";
 
 import { getPromptFile } from "~/utils/prompt";
 import { exit } from "~/utils/process";
@@ -20,7 +20,7 @@ const EMPTY_TEMPLATE = dedent`
   # Add your custom guidelines here.
   # When no guidelines are present, noto will use conventional commits format by default.`;
 
-export const init = gitProcedure
+export const init = authedGitProcedure
   .meta({
     description: "initialize noto in the repository",
   })


### PR DESCRIPTION
This pull request updates the authentication requirements for the `init` command in the CLI tool. The main change is switching from using `gitProcedure` to `authedGitProcedure`, which means the command now requires authentication.

Authentication update:

* Changed the import from `gitProcedure` to `authedGitProcedure` in `packages/cli/src/commands/init.ts`, enforcing authentication for the `init` command.
* Updated the `init` command to use `authedGitProcedure` instead of `gitProcedure` in `packages/cli/src/commands/init.ts`.

Closes #192 