### PR TITLE
feat: open external links in new tab

### DIFF
--- a/apps/web/components/mdx-components.tsx
+++ b/apps/web/components/mdx-components.tsx
@@ -9,13 +9,15 @@ import type { Route } from "next";
 
 export const components = {
   a: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
-    const isExternal = props.href?.startsWith("http");
+    if (!props.href) return <a {...props} />;
 
-    if (isExternal) {
-      return <a target="_blank" rel="noopener noreferrer" {...props} />;
-    }
+    const isExternal = props.href.startsWith("http");
 
-    return <Link href={props.href as Route} {...props} />;
+    return isExternal ? (
+      <a target="_blank" rel="noopener noreferrer" {...props} />
+    ) : (
+      <Link href={props.href as Route} {...props} />
+    );
   },
   code: ({ className, ...props }: CodeBlockCommandProps) => {
     const {


### PR DESCRIPTION
This pull request updates the `apps/web/components/mdx-components.tsx` file to improve how anchor (`<a>`) tags are rendered in MDX content. The main change is the introduction of logic to distinguish between external and internal links, ensuring better user experience and security.

Improvements to MDX link handling:

* Added a custom `a` component that checks if the link is external (starts with "http") and, if so, renders it with `target="_blank"` and `rel="noopener noreferrer"` for security and usability; otherwise, it uses Next.js's `Link` component for internal navigation.
* Imported `Link` from `next/link` and the `Route` type from `next` to support type-safe internal routing.