### PR TITLE
feat(web): add noto guidelines

### DIFF
--- a/apps/web/.noto/commit-prompt.md
+++ b/apps/web/.noto/commit-prompt.md
@@ -1,0 +1,35 @@
+# Commit Message Guidelines
+
+## Format
+
+Conventional commits: `type(web): description` or `type: description`
+
+## Style Rules
+
+- **Tense**: Imperative/present ("add", "fix", "update")
+- **Capitalization**: Lowercase first letter
+- **Length**: Concise, typically under 70 characters
+- **Tone**: Technical and straightforward
+
+## Commit Types
+
+- `feat`: New features or functionality
+- `fix`: Bug fixes and issue resolutions
+- `docs`: Documentation updates
+- `chore`: Routine tasks, maintenance, or updates
+
+## Scope Usage
+
+Use scopes in parentheses to indicate the area affected (e.g., `web`). Omit scope for general changes.
+
+## Description Patterns
+
+Start with an action verb (add, update, handle). Be specific about what was changed or added.
+
+## Examples from History
+
+- feat(web): add `generateStaticParams` and `generateMetadata`
+- fix(web): handle missing href
+- docs(web): add descriptions to docs
+- chore(web): update og image
+


### PR DESCRIPTION
This pull request introduces a new set of commit message guidelines for the project. The guidelines provide a clear structure and style for writing commit messages, including formatting conventions, style rules, commit types, and example usage.

Commit message standards:

* Added a new `apps/web/.noto/commit-prompt.md` file outlining commit message guidelines, including format, style rules, commit types, scope usage, and example messages.