### PR TITLE
chore(cli): handle version flags separately

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,13 @@ import { version } from "package";
 
 import { router } from "~/router";
 
+const args = process.argv.slice(2);
+
+if (args.includes("--version") || args.includes("-v")) {
+  console.log(version);
+  process.exit(0);
+}
+
 void createCli({
   name: "noto",
   router,


### PR DESCRIPTION
This pull request adds support for handling version flags before invoking `trpc-cli`. It detects `-v` and `--version` flags and prints the package version directly, exiting without running the CLI. The existing `-V` flag handled by `trpc-cli` remains unchanged. This improves the user experience by aligning the CLI behavior with common conventions used in other command-line tools.