### PR TITLE
fix(ci): update github tokens for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,17 @@ on:
     tags:
       - "v*"
 
+  workflow_dispatch:
+    inputs:
+      use-npm:
+        description: Should npm packages be published?
+        type: boolean
+        default: true
+      use-homebrew:
+        description: Should the Homebrew tap be updated?
+        type: boolean
+        default: true
+
 permissions:
   contents: write
 
@@ -14,6 +25,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || inputs.use-npm == true }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -69,7 +81,15 @@ jobs:
   homebrew:
     needs: release
     runs-on: ubuntu-latest
-    if: "!contains(github.ref, 'next') && !contains(github.ref, 'canary') && !contains(github.ref, 'beta') && !contains(github.ref, 'rc')"
+    if: >
+      (
+        github.event_name == 'push' ||
+        inputs.use-homebrew == true
+      ) &&
+      !contains(github.ref, 'next') &&
+      !contains(github.ref, 'canary') &&
+      !contains(github.ref, 'beta') &&
+      !contains(github.ref, 'rc')
     steps:
       - name: Checkout homebrew-noto
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` workflow to add manual control over publishing npm packages and updating the Homebrew tap. It introduces workflow dispatch inputs, refines job conditions to respect these inputs, and corrects token usage for publishing. These changes make the release process more flexible and secure.

**Workflow dispatch enhancements:**

* Added `workflow_dispatch` with `use-npm` and `use-homebrew` boolean inputs, allowing manual triggering and control over which release steps are executed.

**Conditional job execution:**

* Updated the `release` job to run only if triggered by a push or if `use-npm` is true, ensuring npm publishing only occurs when intended.
* Refined the `homebrew` job condition to consider both push events and the `use-homebrew` input, while still excluding pre-release branches.

**Token usage corrections:**

* Changed the token used for changelog generation to the default `GITHUB_TOKEN` for improved security and compatibility.
* Updated the Homebrew checkout step to use the dedicated `HOMEBREW_TAP_TOKEN` instead of the default token, ensuring proper permissions for tap updates.

Closes #207