### PR TITLE
feat(web): add `scroll-to-anchor` component

### DIFF
--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -5,6 +5,7 @@ import { MDXContent } from "@content-collections/mdx/react";
 import { AnchorProvider } from "~/components/toc";
 import { TOCMobile } from "~/components/toc-mobile";
 import { TOCDesktop } from "~/components/toc-desktop";
+import { ScrollToAnchor } from "~/components/scroll-to-anchor";
 
 import { components } from "~/components/mdx-components";
 
@@ -62,6 +63,7 @@ export default async function Page({ params }: PageProps) {
         </div>
       </div>
       <TOCDesktop />
+      <ScrollToAnchor />
     </AnchorProvider>
   );
 }

--- a/apps/web/components/scroll-to-anchor.tsx
+++ b/apps/web/components/scroll-to-anchor.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import * as React from "react";
+
+export function ScrollToAnchor() {
+  React.useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash) return;
+
+    const id = decodeURIComponent(hash.replace("#", ""));
+
+    setTimeout(() => {
+      const el = document.getElementById(id);
+      if (!el) return;
+
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 100);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
This pull request introduces a new client-side feature to improve navigation within documentation pages by automatically scrolling to anchor links when a hash is present in the URL. The main changes include adding the `ScrollToAnchor` component and integrating it into the documentation page layout.

### Feature Addition: Smooth Anchor Navigation

* Added a new `ScrollToAnchor` React component in `scroll-to-anchor.tsx` that listens for URL hash changes and smoothly scrolls to the corresponding element on page load.

### Integration with Documentation Page

* Imported `ScrollToAnchor` into `page.tsx` and rendered it within the documentation layout, ensuring anchor navigation works seamlessly alongside the table of contents components. ([apps/web/app/docs/[[...slug]]/page.tsxR8](diffhunk://#diff-d6f23f8532bccfdc376b1feb45cc358370d536a147bb5ea6502abd18665d6eecR8), [apps/web/app/docs/[[...slug]]/page.tsxR66](diffhunk://#diff-d6f23f8532bccfdc376b1feb45cc358370d536a147bb5ea6502abd18665d6eecR66))