### PR TITLE
fix(cli): use `NOTO_API_KEY` env variable if present

### DIFF
--- a/packages/cli/src/ai/models.ts
+++ b/packages/cli/src/ai/models.ts
@@ -7,7 +7,10 @@ import type { LanguageModelV2 } from "@ai-sdk/provider";
 import type { AvailableModels } from "~/ai/types";
 
 const google = createGoogleGenerativeAI({
-  apiKey: (await StorageManager.get()).llm?.apiKey ?? "api-key",
+  apiKey:
+    process.env.NOTO_API_KEY ||
+    (await StorageManager.get()).llm?.apiKey ||
+    "api-key",
 });
 
 export const DEFAULT_MODEL: AvailableModels = "gemini-2.0-flash";


### PR DESCRIPTION
This pull request updates the way the Google Generative AI API key is retrieved in the `packages/cli/src/ai/models.ts` file. The change improves flexibility and security by allowing the API key to be set via an environment variable.

API key retrieval improvement:

* The `apiKey` for the Google Generative AI client will now first check for the `NOTO_API_KEY` environment variable, then fallback to the stored key in `StorageManager`, and finally to a default value if neither is present.

Closes #212