### PR TITLE
docs(web): fix typo in brew install command

### DIFF
--- a/apps/web/content/docs/installation.md
+++ b/apps/web/content/docs/installation.md
@@ -15,7 +15,7 @@ Getting noto up and running takes less than a minute. Let's walk through it.
 
 Install noto globally using package manager of your choice.
 
-```bash brew="brew install @snelusha/noto/noto"
+```bash brew="brew install snelusha/noto/noto"
 npm install -g @snelusha/noto
 ```
 


### PR DESCRIPTION
This pull request updates the installation instructions in the documentation to use the correct Homebrew tap for installing `noto`.

Documentation update:

* Updated the Homebrew installation command in `apps/web/content/docs/installation.md` to use `snelusha/noto/noto` instead of `@snelusha/noto/noto`.