### PR TITLE
feat: add build time environment variables for version

### DIFF
--- a/packages/cli/bunup.config.ts
+++ b/packages/cli/bunup.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "bunup";
 
+import { version } from "package";
+
 export default defineConfig({
   entry: ["src/index.ts"],
   minify: true,
   banner: "#!/usr/bin/env node",
   footer: "// Made by a human on earth!",
+  env: {
+    NODE_ENV: "production",
+    VERSION: version,
+  },
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,12 @@
 import { createCli } from "trpc-cli";
 
-import { version } from "package";
+import { version as packageVersion } from "package";
 
 import { router } from "~/router";
 
 const args = process.argv.slice(2);
+
+const version = process.env.VERSION ?? packageVersion;
 
 if (args.includes("--version") || args.includes("-v")) {
   console.log(version);


### PR DESCRIPTION
This pull request updates the CLI to improve how the application version is managed and displayed. The changes ensure that the version is consistently injected into the environment and used throughout the CLI, making version reporting more reliable.

**Version management improvements:**

* Added the `version` from `package` to the `env` configuration in `bunup.config.ts`, ensuring it is available as an environment variable at runtime.
* In `src/index.ts`, updated the logic to use the version from the environment variable if available, falling back to the package version, and refactored the import to avoid naming conflicts.

Closes #224 