### PR TITLE
fix(web): add explicit content property to `content-collections` schema

### DIFF
--- a/apps/web/content-collections.ts
+++ b/apps/web/content-collections.ts
@@ -23,6 +23,7 @@ const docs = defineCollection({
   directory: "content/docs",
   include: "**/*.md",
   schema: z.object({
+    content: z.string(),
     title: z.string(),
     description: z.string(),
   }),


### PR DESCRIPTION
This pull request makes a minor update to the `docs` collection schema in `apps/web/content-collections.ts`. The change adds a new `content` field of type string to the schema definition.