### PR TITLE
fix(cli): correct package detection

### DIFF
--- a/packages/cli/src/utils/installation-info.ts
+++ b/packages/cli/src/utils/installation-info.ts
@@ -73,7 +73,10 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       } catch {}
     }
 
-    if (realPath.includes("/dlx")) {
+    if (
+      realPath.includes("/pnpm/dlx") ||
+      realPath.includes("/pnpm-cache/dlx")
+    ) {
       return {
         packageManager: PackageManager.PNPX,
         isGlobal: false,

--- a/packages/cli/src/utils/installation-info.ts
+++ b/packages/cli/src/utils/installation-info.ts
@@ -33,12 +33,10 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
   const root = process.cwd();
 
   try {
-    // Normalize path separators to forward slashes for consistent matching.
     const realPath = fs.realpathSync(cliPath).replace(/\\/g, "/");
     const normalizedRoot = root.replace(/\\/g, "/");
     const isGit = await isGitRepository();
 
-    // Check for local git clone first
     if (
       isGit &&
       normalizedRoot &&
@@ -46,14 +44,13 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       !realPath.includes("/node_modules/")
     ) {
       return {
-        packageManager: PackageManager.UNKNOWN, // Not managed by a package manager in this sense
+        packageManager: PackageManager.UNKNOWN,
         isGlobal: false,
         updateMessage:
           'Running from a local git clone. Please update with "git pull".',
       };
     }
 
-    // Check for npx/pnpx
     if (realPath.includes("/.npm/_npx") || realPath.includes("/npm/_npx")) {
       return {
         packageManager: PackageManager.NPX,
@@ -61,18 +58,9 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
         updateMessage: "Running via npx, update not applicable.",
       };
     }
-    if (realPath.includes("/.pnpm/_pnpx")) {
-      return {
-        packageManager: PackageManager.PNPX,
-        isGlobal: false,
-        updateMessage: "Running via pnpx, update not applicable.",
-      };
-    }
 
-    // Check for Homebrew
     if (process.platform === "darwin") {
       try {
-        // The package name in homebrew is noto
         childProcess.execSync('brew list -1 | grep -q "^noto$"', {
           stdio: "ignore",
         });
@@ -82,14 +70,18 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
           updateMessage:
             'Installed via Homebrew. Please update with "brew upgrade".',
         };
-      } catch {
-        // Brew is not installed or noto is not installed via brew.
-        // Continue to the next check.
-      }
+      } catch {}
     }
 
-    // Check for pnpm
-    if (realPath.includes("/.pnpm/global")) {
+    if (realPath.includes("/dlx")) {
+      return {
+        packageManager: PackageManager.PNPX,
+        isGlobal: false,
+        updateMessage: "Running via pnpx, update not applicable.",
+      };
+    }
+
+    if (realPath.includes("/pnpm/global")) {
       const updateCommand = "pnpm add -g @snelusha/noto@latest";
       return {
         packageManager: PackageManager.PNPM,
@@ -99,7 +91,6 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       };
     }
 
-    // Check for yarn
     if (realPath.includes("/.yarn/global")) {
       const updateCommand = "yarn global add @snelusha/noto@latest";
       return {
@@ -110,8 +101,7 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       };
     }
 
-    // Check for bun
-    if (realPath.includes("/.bun/install/cache")) {
+    if (realPath.includes("/bunx")) {
       return {
         packageManager: PackageManager.BUNX,
         isGlobal: false,
@@ -128,7 +118,6 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       };
     }
 
-    // Check for local install
     if (
       normalizedRoot &&
       realPath.startsWith(`${normalizedRoot}/node_modules`)
@@ -152,7 +141,6 @@ export async function getInstallationInfo(): Promise<InstallationInfo> {
       };
     }
 
-    // Assume global npm
     const updateCommand = "npm install -g @snelusha/noto@latest";
     return {
       packageManager: PackageManager.NPM,

--- a/packages/cli/test/installation-info.test.ts
+++ b/packages/cli/test/installation-info.test.ts
@@ -150,6 +150,8 @@ describe("installation-info", () => {
         return Buffer.from("noto");
       });
 
+      Object.defineProperty(process, "platform", { value: "darwin" });
+
       const result = await getInstallationInfo();
 
       expect(result.packageManager).toBe(PackageManager.HOMEBREW);


### PR DESCRIPTION
This pull request updates the logic for detecting how the CLI was installed and revises the corresponding tests to match the new detection methods. The main changes include improved detection for pnpx, pnpm, bunx, and Homebrew installations, as well as test updates for these scenarios.

**Installation detection logic improvements:**

* Changed pnpx detection to look for `/dlx` in the path instead of the previous `/_pnpx`, and removed the old pnpx path check. [[1]](diffhunk://#diff-d112c8b94fdf945e170c6a787c7e2cfe7ced445205e13dc6c842e5bc2df6a38cL36-L75) [[2]](diffhunk://#diff-d112c8b94fdf945e170c6a787c7e2cfe7ced445205e13dc6c842e5bc2df6a38cL85-R84)
* Updated pnpm global installation detection to look for `/pnpm/global` instead of `/.pnpm/global`, reflecting the current installation paths.
* Changed bunx detection to look for `/bunx` in the path instead of the previous bun cache path.
* Improved Homebrew detection by simplifying the error handling and ensuring correct update messaging.

**Test updates for new detection logic:**

* Updated test paths and logic to match the new detection methods for pnpx (`/dlx`), pnpm global (`/local/share/pnpm/global`), bunx, and Homebrew installations. Added child process mocks where needed. [[1]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R92-R104) [[2]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3L109-R127) [[3]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R137-R162) [[4]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R172-R174) [[5]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R188) [[6]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R198-R200)
* Added missing child process mocks to all relevant tests to ensure isolation and prevent side effects. [[1]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R212) [[2]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R225-R227) [[3]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R238) [[4]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R251-R253) [[5]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R264) [[6]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R277-R279) [[7]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R290) [[8]](diffhunk://#diff-aad46e0e3be72119f289f612d67c0b0ddd8cc8a154cf24f4db9e2a3b2ef4f4e3R300-R302)