### PR TITLE
feat(cli): display self update command instead of update message

### DIFF
--- a/packages/cli/src/utils/process.ts
+++ b/packages/cli/src/utils/process.ts
@@ -4,18 +4,13 @@ import dedent from "dedent";
 
 import { getAvailableUpdate } from "~/utils/update";
 
-import { getInstallationInfo } from "~/utils/installation-info";
-
 export async function displayUpdateNotice() {
   const update = await getAvailableUpdate();
-  if (update) {
-    const installationInfo = await getInstallationInfo();
-    const ins = installationInfo.updateMessage;
+  if (update)
     p.log.warn(
       dedent`A new version of noto is available: ${color.dim(update.current)} → ${color.green(update.latest)}
-      ${ins ?? ""}`.trim(),
+      Please run \`noto upgrade\` to update`.trim(),
     );
-  }
 }
 
 export const exit = async (code?: number, displayUpdate: boolean = true) => {


### PR DESCRIPTION
This pull request simplifies the update notice logic in the `displayUpdateNotice` function by removing the dependency on installation-specific update messages. Now, when an update is available, users are shown a standardized message prompting them to run `noto upgrade`.

Improvements to update notification:

* Simplified the `displayUpdateNotice` function in `process.ts` by removing the call to `getInstallationInfo` and displaying a consistent update message to users, regardless of installation details.