### PR TITLE
fix(cli): check for beta updates

### DIFF
--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -14,13 +14,16 @@ export interface UpdateInfo {
 }
 
 function getBestAvailableUpdate(beta?: string, stable?: string): string | null {
-  if (!beta) return stable || null;
-  if (!stable) return beta || null;
+  if (!beta || !stable) return beta || stable || null;
 
-  if (semver.coerce(stable)?.version === semver.coerce(beta)?.version)
-    return beta;
+  const stableVersion = semver.coerce(stable)?.version;
+  const betaVersion = semver.coerce(beta)?.version;
 
-  return semver.gt(stable, beta) ? stable : beta;
+  if (!stableVersion || !betaVersion) return beta || stable || null;
+
+  return stableVersion === betaVersion || semver.gt(betaVersion, stableVersion)
+    ? beta
+    : stable;
 }
 
 export async function checkForUpdate(


### PR DESCRIPTION
This pull request updates the update-checking logic in the CLI utility to better handle beta and stable versions. The main improvement is the introduction of a new function to determine the best available update, ensuring users on beta versions are offered the most appropriate update.

Update logic improvements:

* Added a new `getBestAvailableUpdate` function in `update.ts` to select the best update candidate between beta and stable versions, preferring beta if both are the same version or the newer one otherwise.
* Modified the `checkForUpdate` function to use `getBestAvailableUpdate` when the current version is a beta, ensuring correct update suggestions for beta users.

Closes #240