### PR TITLE
feat: add release script

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,7 +56,7 @@
     },
     "packages/cli": {
       "name": "@snelusha/noto",
-      "version": "1.3.3",
+      "version": "1.3.4-beta.2",
       "bin": {
         "noto": "dist/index.js",
       },
@@ -70,7 +70,7 @@
         "dedent": "^1.7.0",
         "latest-version": "^9.0.0",
         "picocolors": "^1.1.1",
-        "semver": "^7.7.3",
+        "semver": "catalog:",
         "simple-git": "^3.28.0",
         "superjson": "^2.2.3",
         "tinyexec": "^1.0.1",
@@ -79,7 +79,7 @@
       },
       "devDependencies": {
         "@types/node": "catalog:",
-        "@types/semver": "^7.7.1",
+        "@types/semver": "catalog:",
         "bunup": "^0.15.7",
         "typescript": "catalog:",
         "vitest": "^4.0.3",
@@ -87,7 +87,10 @@
     },
   },
   "catalog": {
+    "@types/bun": "^1.3.3",
     "@types/node": "^24.10.1",
+    "@types/semver": "^7.7.1",
+    "semver": "^7.7.3",
     "typescript": "^5.9.3",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "turbo": "^2.5.8"
   },
   "license": "MIT",
-  "packageManager": "bun@1.2.23",
+  "packageManager": "bun@1.3.3",
   "private": true,
   "scripts": {
     "dev": "turbo dev",
@@ -19,7 +19,10 @@
       "packages/*"
     ],
     "catalog": {
+      "@types/bun": "^1.3.3",
       "@types/node": "^24.10.1",
+      "@types/semver": "^7.7.1",
+      "semver": "^7.7.3",
       "typescript": "^5.9.3"
     }
   }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,7 +43,7 @@
   ],
   "devDependencies": {
     "@types/node": "catalog:",
-    "@types/semver": "^7.7.1",
+    "@types/semver": "catalog:",
     "bunup": "^0.15.7",
     "typescript": "catalog:",
     "vitest": "^4.0.3"
@@ -58,7 +58,7 @@
     "dedent": "^1.7.0",
     "latest-version": "^9.0.0",
     "picocolors": "^1.1.1",
-    "semver": "^7.7.3",
+    "semver": "catalog:",
     "simple-git": "^3.28.0",
     "superjson": "^2.2.3",
     "tinyexec": "^1.0.1",

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun";
+
+import semver from "semver";
+
+const packages = ["packages/cli", "apps/web"];
+
+const pkgJson = await Bun.file("packages/cli/package.json").json();
+
+function error(message: string): never {
+  throw new Error(message);
+}
+
+function bumpVersion(version: string, type: semver.ReleaseType | string) {
+  if (
+    !semver.RELEASE_TYPES.includes(type as semver.ReleaseType) &&
+    semver.valid(type)
+  ) {
+    if (!semver.gt(type, version))
+      error(
+        `specified version is not greater than current version: ${type} <= ${version}`,
+      );
+    return type;
+  }
+
+  const isPrelease = type === "prerelease";
+  const bumpedVersion = isPrelease
+    ? semver.inc(version, type, "beta")
+    : semver.inc(version, type as semver.ReleaseType);
+
+  if (!bumpedVersion) error(`failed to bump version: ${version} -> ${type}`);
+  return bumpedVersion;
+}
+
+async function isGitClean() {
+  const status = await $`git status --porcelain`.text();
+  return status.trim().length === 0;
+}
+
+async function updatePackageVersions(version: string) {
+  const changedFiles: string[] = [];
+
+  for (const pkg of packages) {
+    const pkgJsonPath = `${pkg}/package.json`;
+    const pkgJson = await Bun.file(pkgJsonPath).json();
+    pkgJson.version = version;
+    await Bun.write(pkgJsonPath, `${JSON.stringify(pkgJson, null, 2)}\n`);
+    changedFiles.push(pkgJsonPath);
+    console.log(`bumped version in ${pkgJsonPath} to ${version}`);
+  }
+
+  return changedFiles;
+}
+
+async function release() {
+  const type = process.argv[2];
+
+  if (!type) error("please specify a release type or version");
+  if (
+    !semver.RELEASE_TYPES.includes(type as semver.ReleaseType) &&
+    !semver.valid(type)
+  )
+    error(`invalid release type or version: ${type}`);
+
+  if (!(await isGitClean())) error("git working directory is not clean");
+
+  const newVersion = bumpVersion(pkgJson.version, type);
+
+  if (process.stdin.isTTY) {
+    const confirm = prompt(`release version '${newVersion}'? (y/n): `);
+    if (!confirm?.toLowerCase().startsWith("y")) {
+      console.log("aborting release");
+      process.exit(0);
+    }
+  }
+
+  const files = await updatePackageVersions(newVersion);
+  await $`git add ${files}`;
+
+  const commit = `chore(release): v${newVersion}`;
+  await $`git commit -m ${commit}`;
+  console.log(`created git commit: ${commit}`);
+
+  const tag = `v${newVersion}`;
+  await $`git tag ${tag} -m "release ${tag}"`;
+  console.log(`created git tag: ${tag}`);
+
+  console.log("release complete");
+}
+
+release().catch((e) => console.error("release failed:", e.message));


### PR DESCRIPTION
This pull request introduces a new release automation script and updates package dependencies to support it. The key changes include adding a script to automate version bumps and git tagging, updating the `bun` package manager version, and centralizing type and dependency management for `semver` and `bun` across the repository.

Release automation:

* Added a new `scripts/release.ts` script that automates version bumping, git commits, and tagging for releases using Bun and `semver`.

Dependency and package manager updates:

* Updated the `bun` package manager version in `package.json` from `1.2.23` to `1.3.3` for improved compatibility and features.
* Added `@types/bun`, `@types/semver`, and `semver` as catalog dependencies in the root `package.json` to centralize type and version management.

Dependency deduplication for CLI package:

* Changed the `packages/cli/package.json` to use catalog references for `@types/semver` and `semver`, reducing duplication and ensuring consistency with the root configuration. [[1]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L46-R46) [[2]](diffhunk://#diff-6e2e2a1851648938b325ba84de634407a4e69a644ea61102df15ca4a8a7a9758L61-R61)