### PR TITLE
feat(cli): add pre-release indicator

### DIFF
--- a/packages/cli/src/trpc.ts
+++ b/packages/cli/src/trpc.ts
@@ -8,7 +8,7 @@ import color from "picocolors";
 import dedent from "dedent";
 
 import { getStagedDiff, isGitRepository } from "~/utils/git";
-import { isPrelease } from "./utils/installation-info";
+import { isPrerelease } from "./utils/installation-info";
 import { StorageManager } from "~/utils/storage";
 import { getPromptFile } from "~/utils/prompt";
 import { exit } from "~/utils/process";
@@ -101,8 +101,8 @@ export const baseProcedure = t.procedure.use((opts) => {
 
   if (meta?.intro) {
     console.log();
-    if (isPrelease)
-      p.intro(`${color.bgGreen(color.black(" @snelusha/noto [Prelease] "))}`);
+    if (isPrerelease)
+      p.intro(`${color.bgGreen(color.black(" @snelusha/noto [Prerelease] "))}`);
     else p.intro(`${color.bgCyan(color.black(" @snelusha/noto "))}`);
   }
 

--- a/packages/cli/src/trpc.ts
+++ b/packages/cli/src/trpc.ts
@@ -8,6 +8,7 @@ import color from "picocolors";
 import dedent from "dedent";
 
 import { getStagedDiff, isGitRepository } from "~/utils/git";
+import { isPrelease } from "./utils/installation-info";
 import { StorageManager } from "~/utils/storage";
 import { getPromptFile } from "~/utils/prompt";
 import { exit } from "~/utils/process";
@@ -100,7 +101,9 @@ export const baseProcedure = t.procedure.use((opts) => {
 
   if (meta?.intro) {
     console.log();
-    p.intro(`${color.bgCyan(color.black(" @snelusha/noto "))}`);
+    if (isPrelease)
+      p.intro(`${color.bgGreen(color.black(" @snelusha/noto [Prelease] "))}`);
+    else p.intro(`${color.bgCyan(color.black(" @snelusha/noto "))}`);
   }
 
   return next();

--- a/packages/cli/src/utils/installation-info.ts
+++ b/packages/cli/src/utils/installation-info.ts
@@ -5,6 +5,10 @@ import process from "node:process";
 
 import { isGitRepository } from "~/utils/git";
 
+import { version } from "package";
+
+export const isPrelease = version.includes("beta");
+
 export enum PackageManager {
   NPM = "npm",
   YARN = "yarn",

--- a/packages/cli/src/utils/installation-info.ts
+++ b/packages/cli/src/utils/installation-info.ts
@@ -7,7 +7,7 @@ import { isGitRepository } from "~/utils/git";
 
 import { version } from "package";
 
-export const isPrelease = version.includes("beta");
+export const isPrerelease = version.includes("beta");
 
 export enum PackageManager {
   NPM = "npm",

--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -2,7 +2,7 @@ import semver from "semver";
 import latestVersion from "latest-version";
 
 import { CacheManager } from "~/utils/cache";
-import { isPrelease } from "~/utils/installation-info";
+import { isPrerelease } from "~/utils/installation-info";
 
 import { name, version as currentVersion } from "package";
 
@@ -48,7 +48,7 @@ export async function checkForUpdate(
   }
 
   try {
-    const latest = isPrelease
+    const latest = isPrerelease
       ? getBestAvailableUpdate(
           ...(await Promise.all([
             latestVersion(name, { version: "beta" }),

--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -2,6 +2,7 @@ import semver from "semver";
 import latestVersion from "latest-version";
 
 import { CacheManager } from "~/utils/cache";
+import { isPrelease } from "~/utils/installation-info";
 
 import { name, version as currentVersion } from "package";
 
@@ -47,9 +48,7 @@ export async function checkForUpdate(
   }
 
   try {
-    const isBeta = currentVersion.includes("beta");
-
-    const latest = isBeta
+    const latest = isPrelease
       ? getBestAvailableUpdate(
           ...(await Promise.all([
             latestVersion(name, { version: "beta" }),


### PR DESCRIPTION
This pull request introduces logic to better distinguish between pre-release (`beta`) and stable versions of the CLI tool. The main change is the introduction of the `isPrelease` flag, which is now used throughout the codebase to conditionally display pre-release information and fetch the appropriate update version.

Versioning and update logic improvements:

* Added the `isPrelease` flag in `utils/installation-info.ts`, which checks if the current version includes "beta" and exports it for use elsewhere.
* Updated the update check logic in `utils/update.ts` to use `isPrelease` instead of duplicating the version check, ensuring the correct update channel is selected. [[1]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8R5) [[2]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8L50-R51)

User interface enhancements:

* Changed the CLI intro banner in `trpc.ts` to display a green background and "[Prelease]" label when running a pre-release version, improving user awareness.
* Imported `isPrelease` in `trpc.ts` to enable the new intro banner logic.

Closes #243 