### PR TITLE
fix(cli): use beta tag for prerelease upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -41,7 +41,13 @@ export const upgrade = baseProcedure
       return await exit(1, false);
     }
 
-    const updateProcess = spawn(installationInfo.updateCommand, {
+    const isPrerelease = update.latest.includes("beta");
+
+    const updateCommand = isPrerelease
+      ? installationInfo.updateCommand.replace("@latest", "@beta")
+      : installationInfo.updateCommand;
+
+    const updateProcess = spawn(updateCommand, {
       stdio: "pipe",
       shell: true,
     });

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import * as p from "@clack/prompts";
 import color from "picocolors";
 
+import semver from "semver";
+
 import { baseProcedure } from "~/trpc";
 
 import { exit } from "~/utils/process";
@@ -41,7 +43,7 @@ export const upgrade = baseProcedure
       return await exit(1, false);
     }
 
-    const isPrerelease = update.latest.includes("beta");
+    const isPrerelease = semver.prerelease(update.latest) !== null;
 
     const updateCommand = isPrerelease
       ? installationInfo.updateCommand.replace("@latest", "@beta")

--- a/packages/cli/src/utils/installation-info.ts
+++ b/packages/cli/src/utils/installation-info.ts
@@ -3,11 +3,13 @@ import * as path from "node:path";
 import * as childProcess from "node:child_process";
 import process from "node:process";
 
+import semver from "semver";
+
 import { isGitRepository } from "~/utils/git";
 
 import { version } from "package";
 
-export const isPrerelease = version.includes("beta");
+export const isPrerelease = semver.prerelease(version) !== null;
 
 export enum PackageManager {
   NPM = "npm",


### PR DESCRIPTION
This pull request updates the upgrade command logic in the CLI to ensure that prerelease versions are handled correctly. Specifically, it checks if the latest version is a beta release and adjusts the update command accordingly.

Upgrade command improvements:

* The code now detects if the latest version is a prerelease (contains "beta") and replaces `@latest` with `@beta` in the update command to ensure the correct version is installed.