### PR TITLE
chore(cli): increase update check interval to 24 hours

### DIFF
--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -6,7 +6,7 @@ import { isPrerelease } from "~/utils/installation-info";
 
 import { name, version as currentVersion } from "package";
 
-const UPDATE_CHECK_INTERVAL = 12 * 60 * 60 * 1000;
+const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000;
 
 export interface UpdateInfo {
   latest: string;


### PR DESCRIPTION
This pull request makes a minor change to the update check interval in the CLI utility code. The interval has been increased from 12 hours to 24 hours to reduce the frequency of update checks.