### PR TITLE
feat(cli): update available models and default to `gemini-2.5-flash-lite`

### DIFF
--- a/packages/cli/src/ai/models.ts
+++ b/packages/cli/src/ai/models.ts
@@ -13,22 +13,13 @@ const google = createGoogleGenerativeAI({
     "api-key",
 });
 
-export const DEFAULT_MODEL: AvailableModels = "gemini-2.0-flash";
+export const DEFAULT_MODEL: AvailableModels = "gemini-2.5-flash-lite";
 
 export const models: Record<AvailableModels, LanguageModelV2> = {
-  "gemini-1.5-flash": google("gemini-1.5-flash"),
-  "gemini-1.5-flash-latest": google("gemini-1.5-flash-latest"),
-  "gemini-1.5-flash-8b": google("gemini-1.5-flash-8b"),
-  "gemini-1.5-flash-8b-latest": google("gemini-1.5-flash-8b-latest"),
-  "gemini-1.5-pro": google("gemini-1.5-pro"),
-  "gemini-1.5-pro-latest": google("gemini-1.5-pro-latest"),
-  "gemini-2.0-flash-001": google("gemini-2.0-flash-001"),
-  "gemini-2.0-flash": google("gemini-2.0-flash"),
-  "gemini-2.0-flash-lite-preview-02-05": google(
-    "gemini-2.0-flash-lite-preview-02-05",
-  ),
-  "gemini-2.5-flash-preview-04-17": google("gemini-2.5-flash-preview-04-17"),
-  "gemini-2.5-pro-preview-05-06": google("gemini-2.5-pro-preview-05-06"),
+  "gemini-2.5-flash": google("gemini-2.5-flash"),
+  "gemini-2.5-flash-lite": google("gemini-2.5-flash-lite"),
+  "gemini-2.5-pro": google("gemini-2.5-pro"),
+  "gemini-3-pro-preview": google("gemini-3-pro-preview"),
 };
 
 export const availableModels = Object.keys(models) as AvailableModels[];

--- a/packages/cli/src/ai/types.ts
+++ b/packages/cli/src/ai/types.ts
@@ -1,17 +1,10 @@
 import { z } from "zod";
 
 export const AvailableModelsSchema = z.enum([
-  "gemini-1.5-flash",
-  "gemini-1.5-flash-latest",
-  "gemini-1.5-flash-8b",
-  "gemini-1.5-flash-8b-latest",
-  "gemini-1.5-pro",
-  "gemini-1.5-pro-latest",
-  "gemini-2.0-flash-001",
-  "gemini-2.0-flash",
-  "gemini-2.0-flash-lite-preview-02-05",
-  "gemini-2.5-flash-preview-04-17",
-  "gemini-2.5-pro-preview-05-06",
+  "gemini-2.5-flash",
+  "gemini-2.5-flash-lite",
+  "gemini-2.5-pro",
+  "gemini-3-pro-preview",
 ]);
 
 export type AvailableModels = z.infer<typeof AvailableModelsSchema>;


### PR DESCRIPTION
This pull request updates the available AI models for the CLI, removing older Gemini versions and adding support for newer Gemini 2.5 and Gemini 3 models. The default model has also been updated to the latest Gemini 2.5 flash lite variant.

**Model updates:**

* Removed support for older Gemini models and preview variants, including all Gemini 1.5 and Gemini 2.0 models. (`packages/cli/src/ai/models.ts`, `packages/cli/src/ai/types.ts`) [[1]](diffhunk://#diff-68f53be939742b417869587b77c817ad75ce82cf3e9e462053352aa6a7fd8cfeL16-R22) [[2]](diffhunk://#diff-ebcb63bf59edbc7e074cb7637fc57d27490d90642c71c5ffcf0ac0354f128008L4-R7)
* Added support for new Gemini models: `gemini-2.5-flash`, `gemini-2.5-flash-lite`, `gemini-2.5-pro`, and `gemini-3-pro-preview`. (`packages/cli/src/ai/models.ts`, `packages/cli/src/ai/types.ts`) [[1]](diffhunk://#diff-68f53be939742b417869587b77c817ad75ce82cf3e9e462053352aa6a7fd8cfeL16-R22) [[2]](diffhunk://#diff-ebcb63bf59edbc7e074cb7637fc57d27490d90642c71c5ffcf0ac0354f128008L4-R7)
* Changed the default model to `gemini-2.5-flash-lite` for improved performance and up-to-date capabilities. (`packages/cli/src/ai/models.ts`)

Closes #249 