### PR TITLE
fix(cli): clear update cache after successful upgrade

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -2,12 +2,12 @@ import { spawn } from "node:child_process";
 
 import * as p from "@clack/prompts";
 import color from "picocolors";
-
 import semver from "semver";
 
 import { baseProcedure } from "~/trpc";
 
 import { exit } from "~/utils/process";
+import { CacheManager } from "~/utils/cache";
 import { getAvailableUpdate } from "~/utils/update";
 import { getInstallationInfo } from "~/utils/installation-info";
 
@@ -69,5 +69,11 @@ export const upgrade = baseProcedure
       );
       return await exit(1, false);
     }
+
+    await CacheManager.update((current) => ({
+      ...current,
+      update: undefined,
+    }));
+
     return await exit(0, false);
   });


### PR DESCRIPTION
This pull request introduces a minor update to the upgrade workflow in the CLI, focusing on cache management after a successful update. The key change ensures that any cached update information is cleared once the upgrade completes.

Cache management improvement:

* After a successful upgrade, the `CacheManager.update` method is called to remove the cached `update` entry, ensuring the cache reflects the current state and preventing stale update prompts.

Dependency update:

* The `CacheManager` is now imported in `packages/cli/src/commands/upgrade.ts` to support the cache clearing logic.