### PR TITLE
fix(cli): use specific version for upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -45,9 +45,10 @@ export const upgrade = baseProcedure
 
     const isPrerelease = semver.prerelease(update.latest) !== null;
 
-    const updateCommand = isPrerelease
-      ? installationInfo.updateCommand.replace("@latest", "@beta")
-      : installationInfo.updateCommand;
+    const updateCommand = installationInfo.updateCommand.replace(
+      "@latest",
+      isPrerelease ? "@beta" : `@${update.latest}`,
+    );
 
     const updateProcess = spawn(updateCommand, {
       stdio: "pipe",


### PR DESCRIPTION
This pull request updates the logic for constructing the update command in the `upgrade` CLI command. The change ensures that the correct version tag is used when running the update, supporting both prerelease and specific version updates.

Update command construction:

* Modified the logic in `upgrade.ts` so that if the latest version is a prerelease, `@latest` is replaced with `@beta`, otherwise it is replaced with the specific latest version (e.g., `@1.2.3`). This ensures the correct version is targeted during upgrades.