### PR TITLE
fix(release): skip web app prerelease version updates

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -38,10 +38,14 @@ async function isGitClean() {
   return status.trim().length === 0;
 }
 
-async function updatePackageVersions(version: string) {
+async function updatePackageVersions(
+  version: string,
+  type: semver.ReleaseType | string,
+) {
   const changedFiles: string[] = [];
 
   for (const pkg of packages) {
+    if (type === "prerelease" && pkg === "apps/web") continue;
     const pkgJsonPath = `${pkg}/package.json`;
     const pkgJson = await Bun.file(pkgJsonPath).json();
     pkgJson.version = version;
@@ -75,7 +79,7 @@ async function release() {
     }
   }
 
-  const files = await updatePackageVersions(newVersion);
+  const files = await updatePackageVersions(newVersion, type);
   await $`git add ${files}`;
 
   const commit = `chore(release): v${newVersion}`;


### PR DESCRIPTION
This pull request updates the release script to improve how package versions are updated during a prerelease. The main change is that the `apps/web` package is now excluded from version updates when performing a prerelease.

Release script improvements:

* Updated the `updatePackageVersions` function to accept a `type` parameter and skip updating the `apps/web` package when the release type is `"prerelease"`.
* Modified the `release` function to pass the `type` argument to `updatePackageVersions`, ensuring the new logic is applied during the release process.