### PR TITLE
fix: add dev deps from catalog

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,9 @@
       "name": "@snelusha/noto",
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
+        "semver": "catalog:",
         "turbo": "^2.6.3",
+        "typescript": "catalog:",
       },
     },
     "apps/web": {
@@ -84,6 +86,10 @@
         "vitest": "^4.0.15",
       },
     },
+  },
+  "overrides": {
+    "@types/bun": "catalog:",
+    "semver": "catalog:",
   },
   "catalog": {
     "@types/bun": "^1.3.3",
@@ -1297,10 +1303,6 @@
     "zod": ["zod@4.1.13", "", {}, "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@esbuild-plugins/node-resolve/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@snelusha/noto",
   "version": "0.0.0",
-  "devDependencies": {
-    "@biomejs/biome": "2.3.8",
-    "turbo": "^2.6.3"
-  },
   "license": "MIT",
   "packageManager": "bun@1.3.3",
   "private": true,
@@ -28,5 +24,14 @@
       "typescript": "^5.9.3",
       "zod": "^4.1.13"
     }
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.3.8",
+    "turbo": "^2.6.3",
+    "semver": "catalog:",
+    "typescript": "catalog:"
+  },
+  "overrides": {
+    "@types/bun": "catalog:"
   }
 }


### PR DESCRIPTION
This pull request reorganizes the `devDependencies` section in the `package.json` file and introduces an `overrides` section. The main goal is to improve the structure and maintainability of the project's dependency management.

**Dependency management improvements:**

* Moved the `devDependencies` block to the end of the `package.json` file and expanded it to include additional catalog-based dependencies such as `semver` and `typescript`.
* Added an `overrides` section to explicitly specify the version of `@types/bun` using the `catalog:` source.
* Removed the previous inline `devDependencies` section from the top of the file to avoid duplication and improve clarity.