### PR TITLE
fix(cli): remove pro model confirmation

### DIFF
--- a/packages/cli/src/commands/config/model.ts
+++ b/packages/cli/src/commands/config/model.ts
@@ -29,18 +29,6 @@ export const model = baseProcedure
       return await exit(1);
     }
 
-    if (model === "gemini-2.5-pro-preview-05-06") {
-      const confirm = await p.confirm({
-        message:
-          "this model does not have free quota tier, do you want to continue?",
-      });
-
-      if (p.isCancel(confirm) || !confirm) {
-        p.log.error(color.red("nothing changed!"));
-        return await exit(1);
-      }
-    }
-
     await StorageManager.update((current) => ({
       ...current,
       llm: {


### PR DESCRIPTION
This pull request removes the confirmation prompt when selecting the `gemini-2.5-pro-preview-05-06` model in the `model` CLI command. Now, users will no longer be warned about the lack of a free quota tier for this model during configuration.