### PR TITLE
docs(web): update configuration and add upgrade instructions

### DIFF
--- a/apps/web/content/docs/configuration.md
+++ b/apps/web/content/docs/configuration.md
@@ -19,7 +19,7 @@ noto config key "your-gemini-api-key-here"
 
 ## Model Selection
 
-noto uses `gemini-2.0-flash` by default. To change the model:
+noto uses `gemini-2.5-flash-lite` by default. To change the model:
 
 ```bash
 noto config model

--- a/apps/web/content/docs/installation.md
+++ b/apps/web/content/docs/installation.md
@@ -55,4 +55,16 @@ noto --version
 
 You should see the current version number. If you do, you're all set!
 
-**Having trouble?** Check out our [troubleshooting guide](/docs/troubleshooting) or [open an issue](https://github.com/snelusha/noto/issues) on GitHub.
+## Upgrading noto
+
+Keep noto up to date with the latest features and improvements:
+
+```bash
+noto upgrade
+```
+
+noto will automatically check for available updates and install the latest version. If you're already on the latest version, you'll be notified.
+
+> **Note:** The upgrade command automatically handles both stable and prerelease versions. If a prerelease version is available, it will be offered accordingly.
+
+**Having trouble?** Check out our [troubleshooting guide](/docs/reference/faq) or [open an issue](https://github.com/snelusha/noto/issues) on GitHub.


### PR DESCRIPTION
This pull request updates the documentation for `noto` with a new default model and adds instructions for upgrading the tool. The most important changes are:

Documentation updates:

* Updated the default model in the configuration guide to `gemini-2.5-flash-lite` instead of `gemini-2.0-flash`.

Installation and upgrade instructions:

* Added a new section to the installation guide documenting the `noto upgrade` command, including details on how it checks for and installs updates for both stable and prerelease versions.
* Updated the troubleshooting guide link in the installation documentation to point to the FAQ reference section.

Closes #258 