### PR TITLE
feat(cli): add `gemini-3-flash-preview` model

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@snelusha/noto",
@@ -63,11 +62,11 @@
         "noto": "dist/index.js",
       },
       "dependencies": {
-        "@ai-sdk/google": "^2.0.46",
+        "@ai-sdk/google": "^2.0.49",
         "@ai-sdk/provider": "^2.0.0",
         "@clack/prompts": "^0.11.0",
         "@trpc/server": "^11.8.0",
-        "ai": "^5.0.113",
+        "ai": "^5.0.115",
         "clipboardy": "^5.0.2",
         "dedent": "^1.7.0",
         "latest-version": "^9.0.0",
@@ -102,9 +101,9 @@
     "zod": "^4.1.13",
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.21", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-BwV7DU/lAm3Xn6iyyvZdWgVxgLu3SNXzl5y57gMvkW4nGhAOV5269IrJzQwGt03bb107sa6H6uJwWxc77zXoGA=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.22", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19", "@vercel/oidc": "3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6fHjDfCbjfj4vyMExuLei7ir2///E5sNwNZaobdJsJIxJjDSsjzSLGO/aUI7p9eOnB8XctDrDSF5ilwDGpi6eg=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@2.0.46", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-8PK6u4sGE/kXebd7ZkTp+0aya4kNqzoqpS5m7cHY2NfTK6fhPc6GNvE+MZIZIoHQTp5ed86wGBdeBPpFaaUtyg=="],
+    "@ai-sdk/google": ["@ai-sdk/google@2.0.49", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-efwKk4mOV0SpumUaQskeYABk37FJPmEYwoDJQEjyLRmGSjtHRe9P5Cwof5ffLvaFav2IaJpBGEz98pyTs7oNWA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
 
@@ -634,7 +633,7 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
-    "ai": ["ai@5.0.113", "", { "dependencies": { "@ai-sdk/gateway": "2.0.21", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-26vivpSO/mzZj0k1Si2IpsFspp26ttQICHRySQiMrtWcRd5mnJMX2a8sG28vmZ38C+JUn1cWmfZrsLMxkSMw9g=="],
+    "ai": ["ai@5.0.115", "", { "dependencies": { "@ai-sdk/gateway": "2.0.22", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.19", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-aVuHx0orGxXvhyL7oXUyW8TnWQE6Al8f3Bl6VZjz0WHMV+WaACHPkSyvQ3wje2QCUGzdl5DBF5d+OaXyghPQyg=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,11 +51,11 @@
     "vitest": "^4.0.15"
   },
   "dependencies": {
-    "@ai-sdk/google": "^2.0.46",
+    "@ai-sdk/google": "^2.0.49",
     "@ai-sdk/provider": "^2.0.0",
     "@clack/prompts": "^0.11.0",
     "@trpc/server": "^11.8.0",
-    "ai": "^5.0.113",
+    "ai": "^5.0.115",
     "clipboardy": "^5.0.2",
     "dedent": "^1.7.0",
     "latest-version": "^9.0.0",

--- a/packages/cli/src/ai/models.ts
+++ b/packages/cli/src/ai/models.ts
@@ -19,6 +19,7 @@ export const models: Record<AvailableModels, LanguageModelV2> = {
   "gemini-2.5-flash": google("gemini-2.5-flash"),
   "gemini-2.5-flash-lite": google("gemini-2.5-flash-lite"),
   "gemini-2.5-pro": google("gemini-2.5-pro"),
+  "gemini-3-flash-preview": google("gemini-3-flash-preview"),
   "gemini-3-pro-preview": google("gemini-3-pro-preview"),
 };
 

--- a/packages/cli/src/ai/types.ts
+++ b/packages/cli/src/ai/types.ts
@@ -4,6 +4,7 @@ export const AvailableModelsSchema = z.enum([
   "gemini-2.5-flash",
   "gemini-2.5-flash-lite",
   "gemini-2.5-pro",
+  "gemini-3-flash-preview",
   "gemini-3-pro-preview",
 ]);
 


### PR DESCRIPTION
This pull request updates dependencies and adds support for a new AI model in the CLI package. The most important changes are grouped below:

Dependency updates:

* Updated `@ai-sdk/google` from version `2.0.46` to `2.0.49` and `ai` from `5.0.113` to `5.0.115` in `package.json` to ensure compatibility and access to the latest features.

AI model support:

* Added support for the new `gemini-3-flash-preview` model by updating the `AvailableModelsSchema` enum in `types.ts` and the `models` record in `models.ts`, allowing users to select and use this model in the CLI. [[1]](diffhunk://#diff-ebcb63bf59edbc7e074cb7637fc57d27490d90642c71c5ffcf0ac0354f128008R7) [[2]](diffhunk://#diff-68f53be939742b417869587b77c817ad75ce82cf3e9e462053352aa6a7fd8cfeR22)

Closes #266