### PR TITLE
feat(cli): add `--stable` and `--beta` flags to upgrade command

### DIFF
--- a/apps/web/content/docs/installation.md
+++ b/apps/web/content/docs/installation.md
@@ -65,6 +65,15 @@ noto upgrade
 
 noto will automatically check for available updates and install the latest version. If you're already on the latest version, you'll be notified.
 
-> **Note:** The upgrade command automatically handles both stable and prerelease versions. If a prerelease version is available, it will be offered accordingly.
+### Upgrade Options
+
+Control which version to upgrade to:
+
+```bash
+noto upgrade --stable  # Upgrade to latest stable version
+noto upgrade --beta    # Upgrade to latest beta version
+```
+
+> **Note:** By default, the upgrade command automatically chooses the appropriate version based on your current installation. If you're on a prerelease version, it will check for the best available update (stable or beta). Use `--stable` or `--beta` to explicitly control the upgrade target.
 
 **Having trouble?** Check out our [troubleshooting guide](/docs/reference/faq) or [open an issue](https://github.com/snelusha/noto/issues) on GitHub.

--- a/apps/web/content/docs/usage.md
+++ b/apps/web/content/docs/usage.md
@@ -104,6 +104,25 @@ noto checkout
 noto checkout -b feat/new-feature
 ```
 
+## Upgrading noto
+
+### Check for Updates
+
+Upgrade to the latest version:
+
+```bash
+noto upgrade
+```
+
+### Specific Version Types
+
+Upgrade to stable or beta versions:
+
+```bash
+noto upgrade --stable  # Latest stable version
+noto upgrade --beta    # Latest beta version
+```
+
 ## All Available Flags
 
 **Commit generation:**
@@ -121,6 +140,11 @@ noto checkout -b feat/new-feature
 
 - **`--root`** - Create prompt file in git root
 - **`--generate`** - Generate prompt from existing commits
+
+**Upgrade:**
+
+- **`--stable`** - Upgrade to the latest stable version
+- **`--beta`** - Upgrade to the latest beta version
 
 ## Quick Examples
 

--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -8,6 +8,8 @@ import { name, version as currentVersion } from "package";
 
 const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000;
 
+export type UpdateTag = "stable" | "beta" | "auto";
+
 export interface UpdateInfo {
   latest: string;
   current: string;
@@ -30,6 +32,7 @@ function getBestAvailableUpdate(beta?: string, stable?: string): string | null {
 export async function checkForUpdate(
   mark: boolean = false,
   force: boolean = false,
+  tag: UpdateTag = "stable",
 ): Promise<UpdateInfo> {
   const cached = (await CacheManager.get()).update;
   if (!force && cached) {
@@ -48,14 +51,22 @@ export async function checkForUpdate(
   }
 
   try {
-    const latest = isPrerelease
-      ? (getBestAvailableUpdate(
-          ...(await Promise.all([
-            latestVersion(name, { version: "beta" }),
-            latestVersion(name),
-          ])),
-        ) ?? currentVersion)
-      : await latestVersion(name);
+    let latest: string;
+
+    if (tag === "stable") {
+      latest = await latestVersion(name);
+    } else if (tag === "beta") {
+      latest = await latestVersion(name, { version: "beta" });
+    } else {
+      latest = isPrerelease
+        ? (getBestAvailableUpdate(
+            ...(await Promise.all([
+              latestVersion(name, { version: "beta" }),
+              latestVersion(name),
+            ])),
+          ) ?? currentVersion)
+        : await latestVersion(name);
+    }
 
     const update = {
       latest,
@@ -97,8 +108,9 @@ export async function markUpdateChecked(update: UpdateInfo | null) {
 export async function getAvailableUpdate(
   mark: boolean = false,
   force: boolean = false,
+  tag: UpdateTag = "stable",
 ): Promise<UpdateInfo | null> {
-  const update = await checkForUpdate(mark, force);
+  const update = await checkForUpdate(mark, force, tag);
   const isValid = semver.valid(update.current) && semver.valid(update.latest);
   if (isValid) {
     const isUpToDate = semver.gte(update.current, update.latest);

--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -32,7 +32,7 @@ function getBestAvailableUpdate(beta?: string, stable?: string): string | null {
 export async function checkForUpdate(
   mark: boolean = false,
   force: boolean = false,
-  tag: UpdateTag = "stable",
+  tag: UpdateTag = "auto",
 ): Promise<UpdateInfo> {
   const cached = (await CacheManager.get()).update;
   if (!force && cached) {
@@ -108,7 +108,7 @@ export async function markUpdateChecked(update: UpdateInfo | null) {
 export async function getAvailableUpdate(
   mark: boolean = false,
   force: boolean = false,
-  tag: UpdateTag = "stable",
+  tag: UpdateTag = "auto",
 ): Promise<UpdateInfo | null> {
   const update = await checkForUpdate(mark, force, tag);
   const isValid = semver.valid(update.current) && semver.valid(update.latest);

--- a/packages/cli/test/update.test.ts
+++ b/packages/cli/test/update.test.ts
@@ -19,7 +19,6 @@ import {
 } from "~/utils/update";
 import { CacheManager } from "~/utils/cache";
 
-// Mock the external dependencies
 vi.mock("latest-version", () => ({
   default: vi.fn(),
 }));
@@ -313,6 +312,52 @@ describe("update utilities", () => {
       expect(result).not.toBeNull();
       expect(result?.latest).toBe("1.5.0");
       expect(latestVersion).toHaveBeenCalled();
+    });
+  });
+
+  describe("tag parameter", () => {
+    it('should fetch stable version when tag="stable"', async () => {
+      vi.mocked(latestVersion).mockResolvedValue("1.4.0");
+
+      const result = await checkForUpdate(false, false, "stable");
+
+      expect(result.latest).toBe("1.4.0");
+      expect(latestVersion).toHaveBeenCalledWith("@snelusha/noto");
+    });
+
+    it('should fetch beta version when tag="beta"', async () => {
+      vi.mocked(latestVersion).mockResolvedValue("1.5.0-beta.1");
+
+      const result = await checkForUpdate(false, false, "beta");
+
+      expect(result.latest).toBe("1.5.0-beta.1");
+      expect(latestVersion).toHaveBeenCalledWith("@snelusha/noto", {
+        version: "beta",
+      });
+    });
+
+    it('should return stable update when tag="stable"', async () => {
+      vi.mocked(latestVersion).mockResolvedValue("1.4.0");
+
+      const result = await getAvailableUpdate(false, false, "stable");
+
+      expect(result).toEqual({
+        latest: "1.4.0",
+        current: "1.3.2",
+        timestamp: expect.any(Number),
+      });
+    });
+
+    it('should return beta update when tag="beta"', async () => {
+      vi.mocked(latestVersion).mockResolvedValue("1.5.0-beta.1");
+
+      const result = await getAvailableUpdate(false, false, "beta");
+
+      expect(result).toEqual({
+        latest: "1.5.0-beta.1",
+        current: "1.3.2",
+        timestamp: expect.any(Number),
+      });
     });
   });
 });


### PR DESCRIPTION
This pull request adds support for explicitly upgrading to either the latest stable or beta version of Noto via the CLI, enhances the upgrade command’s flexibility, and updates documentation and tests accordingly. Users can now specify `--stable` or `--beta` flags to control upgrade targets, and the codebase has been refactored to support these options throughout the update logic.

**CLI and Update Logic Enhancements:**

* The `upgrade` command in `upgrade.ts` now accepts `--stable` and `--beta` flags, ensuring users can target specific release channels; the logic prevents selecting both flags simultaneously and passes the chosen tag to update utilities. [[1]](diffhunk://#diff-68403affc1b46520359e1c2576fbd4348aaec4e0299a78abb4c2583c83256adcR18-R50) [[2]](diffhunk://#diff-68403affc1b46520359e1c2576fbd4348aaec4e0299a78abb4c2583c83256adcL50-R77)
* The update utility functions in `update.ts` have been refactored to accept a `tag` parameter (`"stable"`, `"beta"`, or `"auto"`), fetching the appropriate version based on user input or installation state. [[1]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8R11-R12) [[2]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8R35) [[3]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8L51-R69) [[4]](diffhunk://#diff-7b469d4e98e394f10bf1317af30c4b04edc1f5ba3f2f6c70c226c5169b6730c8R111-R113)

**Documentation Updates:**

* The installation and usage docs (`installation.md`, `usage.md`) now clearly document the new upgrade options, including CLI examples and flag descriptions for `--stable` and `--beta`. [[1]](diffhunk://#diff-e9112f4328571546bfa54100bdbb890218322c24f6fe87a4cc1d6145ddf5d3baL68-R77) [[2]](diffhunk://#diff-e26c1e40134cf2848137631cfd7f901d507bd5369dea1b7bc42fd925b9f28e7dR107-R125) [[3]](diffhunk://#diff-e26c1e40134cf2848137631cfd7f901d507bd5369dea1b7bc42fd925b9f28e7dR144-R148)

**Testing Improvements:**

* New tests in `update.test.ts` verify that the update logic correctly fetches the intended version when the `tag` parameter is provided, covering both stable and beta scenarios.

**Dependency and Import Cleanups:**

* Minor import cleanups and the addition of the `zod` library for input validation in the CLI command. [[1]](diffhunk://#diff-68403affc1b46520359e1c2576fbd4348aaec4e0299a78abb4c2583c83256adcR3-R4) [[2]](diffhunk://#diff-e843b1c17a09640e077b903615fe409783386e26774049dccf9c8ec53011a665L22)

Closes #272 