### PR TITLE
fix(cli): prefer stable versions over beta

### DIFF
--- a/packages/cli/src/utils/update.ts
+++ b/packages/cli/src/utils/update.ts
@@ -19,14 +19,12 @@ export interface UpdateInfo {
 function getBestAvailableUpdate(beta?: string, stable?: string): string | null {
   if (!beta || !stable) return beta || stable || null;
 
-  const stableVersion = semver.coerce(stable)?.version;
-  const betaVersion = semver.coerce(beta)?.version;
+  const stableParsed = semver.parse(stable);
+  const betaParsed = semver.parse(beta);
 
-  if (!stableVersion || !betaVersion) return beta || stable || null;
+  if (!stableParsed || !betaParsed) return beta || stable || null;
 
-  return stableVersion === betaVersion || semver.gt(betaVersion, stableVersion)
-    ? beta
-    : stable;
+  return semver.gt(beta, stable) ? beta : stable;
 }
 
 export async function checkForUpdate(

--- a/packages/cli/test/update-prerelease.test.ts
+++ b/packages/cli/test/update-prerelease.test.ts
@@ -24,7 +24,7 @@ vi.mock("package", () => ({
 
 import latestVersion from "latest-version";
 
-import { getAvailableUpdate } from "~/utils/update";
+import { checkForUpdate, getAvailableUpdate } from "~/utils/update";
 
 const tempDir = path.resolve(os.tmpdir(), ".noto-update-prerelease-test");
 const cachePath = path.resolve(tempDir, "cache");
@@ -61,6 +61,23 @@ describe("update utilities - prerelease", () => {
         current: "1.3.6-beta.0",
         timestamp: expect.any(Number),
       });
+    });
+
+    it("should prefer stable over beta prerelease when auto tag on prerelease", async () => {
+      vi.mocked(latestVersion)
+        .mockResolvedValueOnce("1.3.6-beta.5") // beta version
+        .mockResolvedValueOnce("1.3.6"); // stable version
+
+      // When on prerelease 1.3.6-beta.0 with tag="auto",
+      // should prefer stable 1.3.6 over beta 1.3.6-beta.5
+      const result = await checkForUpdate(false, false, "auto");
+
+      expect(result).toEqual({
+        latest: "1.3.6",
+        current: "1.3.6-beta.0",
+        timestamp: expect.any(Number),
+      });
+      expect(latestVersion).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
This pull request improves the logic for determining the best available update version in the CLI update utilities and adds a new test case to ensure correct behavior when preferring stable releases over beta prereleases. The main focus is on more accurately comparing semantic versions and verifying this logic with additional test coverage.

**Update logic improvements:**

* Refactored the `getBestAvailableUpdate` function in `update.ts` to use `semver.parse` for more accurate version parsing and comparison, and simplified the logic to prefer stable releases over beta when appropriate.

**Test coverage enhancements:**

* Added a new test in `update-prerelease.test.ts` to verify that the update check prefers a stable version over a beta prerelease when the tag is set to "auto".
* Updated imports in `update-prerelease.test.ts` to include `checkForUpdate` for the new test case.

Closes #256 