### PR TITLE
fix(web): remove outline from code blocks

### DIFF
--- a/apps/web/styles/prose.css
+++ b/apps/web/styles/prose.css
@@ -353,6 +353,7 @@
   margin-bottom: calc(var(--spacing) * 6);
   padding-top: calc(var(--spacing) * 3.5);
   padding-bottom: calc(var(--spacing) * 3.5);
+  outline: none;
 }
 
 .prose


### PR DESCRIPTION
This pull request makes a minor update to the `apps/web/styles/prose.css` file by adding an `outline: none;` style. This change removes the default outline from the targeted element, likely for visual consistency.

- Added `outline: none;` to the relevant CSS rule to remove default focus outlines.