### PR TITLE
chore(repo): update copyright years

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Sithija Nelusha Silva
+Copyright (c) 2024-2026 Sithija Nelusha Silva
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -139,4 +139,4 @@ Thank you for using noto!
 ## License
 
 This project is licensed under the MIT License.
-© 2025 [Sithija Nelusha Silva](https://github.com/snelusha)
+© 2024-2026 [Sithija Nelusha Silva](https://github.com/snelusha)


### PR DESCRIPTION
This pull request updates the copyright year range in both the `LICENSE` file and the project README to reflect the current coverage period.

- License and documentation updates:
  * Updated the copyright year in the `LICENSE` file from 2025 to 2024-2026.
  * Updated the copyright year in `packages/cli/README.md` to match the new range (2024-2026).