### PR TITLE
style(web): change list style type to square

### DIFF
--- a/apps/web/styles/prose.css
+++ b/apps/web/styles/prose.css
@@ -149,7 +149,7 @@
 }
 
 .prose :where(ul):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  list-style-type: disc;
+  list-style-type: square;
   padding-left: calc(var(--spacing) * 6.5);
   margin-top: calc(var(--spacing) * 5);
   margin-bottom: calc(var(--spacing) * 5);


### PR DESCRIPTION
This pull request makes a small update to the default styling of unordered lists in the `prose.css` file. The list style for `ul` elements has been changed from discs to squares.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure CSS visual change limited to list marker style; no logic, data, or security impact.
> 
> **Overview**
> Updates `apps/web/styles/prose.css` so unordered lists within `.prose` render with *square* bullets instead of *disc*, affecting prose-styled content (e.g., docs pages importing `prose.css`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51e3a262209cebe236d10ac7f55db8b77854694b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->