### PR TITLE
feat(cli): allow string or boolean for `--manual` flag

### DIFF
--- a/apps/web/app/llms.txt/llms.txt
+++ b/apps/web/app/llms.txt/llms.txt
@@ -207,10 +207,16 @@ noto -f  # or --force
 
 ### Manual Commit Message
 
-Write a custom commit message manually:
+Write a custom commit message manually (interactive prompt):
 
 ```bash
 noto --manual
+```
+
+Or pass the commit message inline as a string:
+
+```bash
+noto --manual "chore: init repo"
 ```
 
 ### Working with Previous Messages
@@ -275,7 +281,7 @@ noto upgrade --beta    # Latest beta version
 - `-m, --message` - Provide context for the commit message
 - `-f, --force` - Bypass cache and force regeneration
 - `--push` - Commit and push the changes
-- `--manual` - Write a custom commit message manually
+- `--manual` - Write a custom commit message manually (accepts an optional message string)
 
 ### Previous Message
 - `-e, --edit` - Required with `--amend` (for `noto prev`)

--- a/apps/web/content/docs/usage.md
+++ b/apps/web/content/docs/usage.md
@@ -134,7 +134,7 @@ noto upgrade --beta    # Latest beta version
 - **`-m, --message`** - Provide context for the commit message
 - **`-f, --force`** - Bypass cache and force regeneration of commit message
 - **`--push`** - Commit and push the changes
-- **`--manual`** - Write a custom commit message manually
+- **`--manual`** - Write a custom commit message manually (accepts an optional message string)
 
 **Previous message:**
 
@@ -171,8 +171,11 @@ noto -m "fixing authentication bug"
 # Force regenerate (bypass cache)
 noto -f
 
-# Write manual commit message
+# Write manual commit message (interactive)
 noto --manual
+
+# Provide manual commit message inline
+noto --manual "chore: init repo"
 
 # Copy for manual use
 noto -c

--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -41,7 +41,10 @@ export const noto = authedGitProcedure
         description: "bypass cache and force regeneration of commit message",
         alias: "f",
       }),
-      manual: z.boolean().meta({ description: "custom commit message" }),
+      manual: z
+        .string()
+        .or(z.boolean())
+        .meta({ description: "custom commit message" }),
       model: z.string().optional().meta({
         description: "specify the model to use",
       }),
@@ -54,14 +57,21 @@ export const noto = authedGitProcedure
     try {
       const manual = input.manual;
       if (manual) {
-        const message = await p.text({
-          message: "edit the generated commit message",
-          placeholder: "chore: init repo",
-        });
+        let message: string;
+        if (typeof manual === "string") {
+          message = manual.trim();
+        } else {
+          const enteredMessage = await p.text({
+            message: "enter the commit message",
+            placeholder: "chore: init repo",
+          });
 
-        if (p.isCancel(message)) {
-          p.log.error(color.red("nothing changed!"));
-          return await exit(1);
+          if (p.isCancel(enteredMessage)) {
+            p.log.error(color.red("nothing changed!"));
+            return await exit(1);
+          }
+
+          message = enteredMessage as string;
         }
 
         p.log.step(color.green(message));
@@ -163,7 +173,7 @@ export const noto = authedGitProcedure
       }
 
       const suffix = msg ? `\n${msg}` : "";
-      spin.stop(color.red(`failed to generate commit message${suffix}`), 1);
+      spin.stop(color.red(`failed to generate commit message${suffix}`));
       await exit(1);
     }
   });

--- a/packages/cli/src/commands/noto.ts
+++ b/packages/cli/src/commands/noto.ts
@@ -60,6 +60,10 @@ export const noto = authedGitProcedure
         let message: string;
         if (typeof manual === "string") {
           message = manual.trim();
+          if (!message) {
+            p.log.error(color.red("commit message cannot be empty!"));
+            return await exit(1);
+          }
         } else {
           const enteredMessage = await p.text({
             message: "enter the commit message",


### PR DESCRIPTION
Resolves #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `--manual` flag now supports providing a commit message directly as an inline argument (e.g., `noto --manual "chore: init repo"`), in addition to the existing interactive prompt mode

* **Documentation**
  * Updated documentation to clarify `--manual` flag capabilities and include examples for both interactive and inline usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->