### PR TITLE
chore: update release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ on:
         description: The release version (e.g., v1.2.3)
         required: false
 
-permissions:
-  contents: write
-
 env:
   NOTO_VERSION: ${{ inputs.version || github.ref_name }}
 
@@ -29,6 +26,10 @@ jobs:
   npm:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || inputs.use-npm == true }}
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,6 +96,9 @@ jobs:
       !contains(github.ref, 'canary') &&
       !contains(github.ref, 'beta') &&
       !contains(github.ref, 'rc')
+    permissions:
+      contents: write
+
     steps:
       - name: Wait for npm package availability
         if: needs.npm.result == 'success'


### PR DESCRIPTION
Provenance generation requires `id-token` permission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure and permission configurations to enhance build process security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->