### PR TITLE
feat: allow upgrade to specific version

### DIFF
--- a/apps/web/components/mdx-components.tsx
+++ b/apps/web/components/mdx-components.tsx
@@ -19,7 +19,12 @@ export const components = {
     );
   },
   code: ({ className, ...props }: CodeBlockCommandProps) => {
-    const { __npm__: npm, __pnpm__: pnpm, __bun__: bun, __brew__: brew } = props;
+    const {
+      __npm__: npm,
+      __pnpm__: pnpm,
+      __bun__: bun,
+      __brew__: brew,
+    } = props;
     if (typeof props.children === "string") {
       return <code className={className} {...props} />;
     }

--- a/apps/web/content/docs/installation.md
+++ b/apps/web/content/docs/installation.md
@@ -82,8 +82,9 @@ Control which version to upgrade to:
 ```bash
 noto upgrade --stable  # Upgrade to latest stable version
 noto upgrade --beta    # Upgrade to latest beta version
+noto upgrade 2.0.0     # Install or roll back to an exact version
 ```
 
-> **Note:** By default, the upgrade command automatically chooses the appropriate version based on your current installation. If you're on a prerelease version, it will check for the best available update (stable or beta). Use `--stable` or `--beta` to explicitly control the upgrade target.
+> **Note:** By default, the upgrade command automatically chooses the appropriate version based on your current installation. If you're on a prerelease version, it will check for the best available update (stable or beta). Use `--stable` or `--beta` to explicitly control the upgrade target, or provide an exact version as a positional argument.
 
 **Having trouble?** Check out our [troubleshooting guide](/docs/reference/faq) or [open an issue](https://github.com/snelusha/noto/issues) on GitHub.

--- a/apps/web/lib/transformers.ts
+++ b/apps/web/lib/transformers.ts
@@ -44,7 +44,8 @@ export const transformers = [
             __npm__: (cmd: string) => cmd,
             __pnpm__: (cmd: string) =>
               cmd.replace("npm uninstall", "pnpm remove"),
-            __bun__: (cmd: string) => cmd.replace("npm uninstall", "bun remove"),
+            __bun__: (cmd: string) =>
+              cmd.replace("npm uninstall", "bun remove"),
           },
         },
         {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -142,6 +142,13 @@ Update noto to the latest version:
 noto upgrade
 ```
 
+Install a specific version (including a prerelease):
+
+```bash
+noto upgrade 2.0.0
+noto upgrade 2.0.0-beta.3
+```
+
 > noto will automatically detect your installation method and update itself accordingly.
 
 ## Pro Tips

--- a/packages/cli/src/commands/upgrade.ts
+++ b/packages/cli/src/commands/upgrade.ts
@@ -17,23 +17,39 @@ import { version } from "package";
 
 import type { UpdateTag } from "~/utils/update";
 
-async function performUpgrade(targetVersion: string): Promise<void> {
+export function resolveTargetVersion(target: string): string | null {
+  return semver.valid(target.trim());
+}
+
+async function getUpdateCommand(
+  targetVersion: string,
+  isExplicitTarget: boolean = false,
+): Promise<string | null> {
   const installationInfo = await getInstallationInfo();
   if (!installationInfo.updateCommand) {
     if (installationInfo.updateMessage) {
+      if (isExplicitTarget) {
+        p.log.error(
+          `noto ${targetVersion} cannot be installed automatically. ${installationInfo.updateMessage}`,
+        );
+        await exit(1, false);
+        return null;
+      }
+
       p.log.warn(installationInfo.updateMessage);
-      return await exit(0, false);
+      await exit(0, false);
+      return null;
     }
 
     p.log.error("unable to determine update command for your installation.");
-    return await exit(1, false);
+    await exit(1, false);
+    return null;
   }
 
-  const updateCommand = installationInfo.updateCommand.replace(
-    "@latest",
-    `@${targetVersion}`,
-  );
+  return installationInfo.updateCommand.replace("@latest", `@${targetVersion}`);
+}
 
+async function performUpgrade(updateCommand: string): Promise<void> {
   const updateProcess = spawn(updateCommand, {
     stdio: "pipe",
     shell: true,
@@ -43,6 +59,7 @@ async function performUpgrade(targetVersion: string): Promise<void> {
   spin.start("upgrading noto");
   try {
     await new Promise<void>((resolve, reject) => {
+      updateProcess.on("error", reject);
       updateProcess.on("close", (code) => {
         if (code === 0) resolve();
         else reject();
@@ -51,7 +68,7 @@ async function performUpgrade(targetVersion: string): Promise<void> {
     spin.stop(color.green("noto has been updated successfully!"));
   } catch {
     p.log.error(
-      `automatic update failed. please try updating manually by running: ${installationInfo.updateCommand}`,
+      `automatic update failed. please try updating manually by running: ${updateCommand}`,
     );
     return await exit(1, false);
   }
@@ -70,6 +87,10 @@ export const upgrade = baseProcedure
   })
   .input(
     z.object({
+      target: z.string().optional().meta({
+        positional: true,
+        description: "exact version to install",
+      }),
       stable: z.boolean().optional().meta({
         description: "upgrade to the latest stable version",
       }),
@@ -84,6 +105,26 @@ export const upgrade = baseProcedure
     if (input.stable && input.beta) {
       p.log.error("please choose either --stable or --beta option, not both.");
       return await exit(1, false);
+    }
+
+    if (input.target !== undefined && (input.stable || input.beta)) {
+      p.log.error("a target version cannot be used with --stable or --beta.");
+      return await exit(1, false);
+    }
+
+    if (input.target !== undefined) {
+      const targetVersion = resolveTargetVersion(input.target);
+      if (!targetVersion) {
+        p.log.error(
+          "please provide an exact valid version, for example: noto upgrade 2.0.0",
+        );
+        return await exit(1, false);
+      }
+
+      const updateCommand = await getUpdateCommand(targetVersion, true);
+      if (!updateCommand) return;
+
+      return await performUpgrade(updateCommand);
     }
 
     const tag: UpdateTag = input.stable
@@ -110,5 +151,8 @@ export const upgrade = baseProcedure
     const upgradeVersion =
       isPrerelease || tag === "beta" ? "beta" : update.latest;
 
-    return await performUpgrade(upgradeVersion);
+    const updateCommand = await getUpdateCommand(upgradeVersion);
+    if (!updateCommand) return;
+
+    return await performUpgrade(updateCommand);
   });

--- a/packages/cli/test/upgrade.test.ts
+++ b/packages/cli/test/upgrade.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTargetVersion } from "~/commands/upgrade";
+
+describe("upgrade target versions", () => {
+  it("accepts and normalizes exact stable and prerelease versions", () => {
+    expect(resolveTargetVersion("2.0.0")).toBe("2.0.0");
+    expect(resolveTargetVersion(" v2.0.0-beta.3 ")).toBe("2.0.0-beta.3");
+  });
+
+  it("rejects tags, ranges, and incomplete versions", () => {
+    expect(resolveTargetVersion("latest")).toBeNull();
+    expect(resolveTargetVersion("^2.0.0")).toBeNull();
+    expect(resolveTargetVersion("2.0")).toBeNull();
+  });
+});


### PR DESCRIPTION
Resolves #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgrade to an exact stable or prerelease version using `noto upgrade <version>`.
  - Version input is validated and normalized before installation.
  - Added clearer handling for upgrade failures and manual update instructions.

- **Bug Fixes**
  - Prevented incompatible combinations of an exact version with stable or beta upgrade options.

- **Documentation**
  - Added usage examples for installing specific releases, including prerelease versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->