### PR TITLE
feat: support optional context for `init` command

### DIFF
--- a/apps/web/app/llms.txt/llms.txt
+++ b/apps/web/app/llms.txt/llms.txt
@@ -122,6 +122,7 @@ noto init
 Available flags:
 - `--root` - Create the prompt file in the git root
 - `--generate` - Generate prompt from existing commits (requires 5+ commits)
+- `-m, --message` - Provide context for generated commit-message guidelines
 
 Examples:
 
@@ -129,6 +130,8 @@ Examples:
 noto init --root              # Create in git root
 noto init --generate          # Generate from commits
 noto init --root --generate   # Both options
+noto init -m "Use concise conventional commits with scopes"
+noto init --generate -m "Prefer imperative subjects and ticket IDs"
 ```
 
 noto will create a `.noto/commit-prompt.md` file that defines your commit message style. Commit this file to version control so your entire team uses consistent commit messages.
@@ -275,6 +278,7 @@ noto upgrade --beta    # Latest beta version
 ### Initialization
 - `--root` - Create prompt file in git root
 - `--generate` - Generate prompt from existing commits
+- `-m, --message` - Provide context for generated commit-message guidelines
 
 ### Upgrade
 - `--stable` - Upgrade to the latest stable version
@@ -308,8 +312,11 @@ noto prev -a
 # Amend last commit
 noto prev --amend -e
 
-# Set up custom prompts
+# Set up custom prompts from history
 noto init --root --generate
+
+# Set up custom prompts from a style description
+noto init -m "Use concise conventional commits with scopes"
 ```
 
 ## Common Issues

--- a/apps/web/content/docs/usage.md
+++ b/apps/web/content/docs/usage.md
@@ -81,6 +81,7 @@ noto will interactively ask where to create the file and whether to generate gui
 
 - **`--root`** - Create the prompt file in the git root
 - **`--generate`** - Generate prompt from existing commits (requires 5+ commits)
+- **`-m, --message`** - Provide context for generated commit-message guidelines
 
 **Examples:**
 
@@ -88,6 +89,8 @@ noto will interactively ask where to create the file and whether to generate gui
 noto init --root              # Create in git root
 noto init --generate          # Generate from commits
 noto init --root --generate   # Both options
+noto init -m "Use concise conventional commits with scopes"
+noto init --generate -m "Prefer imperative subjects and ticket IDs"
 ```
 
 > **Note:** Learn more about custom prompts in [Configuration](/docs/configuration#commit-prompts).
@@ -132,6 +135,7 @@ noto upgrade --beta    # Latest beta version
 
 - **`--root`** - Create prompt file in git root
 - **`--generate`** - Generate prompt from existing commits
+- **`-m, --message`** - Provide context for generated commit-message guidelines
 
 **Upgrade:**
 
@@ -175,8 +179,11 @@ noto prev -p
 # Amend last commit
 noto prev --amend
 
-# Set up custom prompts
+# Set up custom prompts from history
 noto init --root --generate
+
+# Set up custom prompts from a style description
+noto init -m "Use concise conventional commits with scopes"
 ```
 
 > **Tip:** Need to configure API keys or models? Check out [Configuration](/docs/configuration) for setup instructions. Using custom commit prompts? noto automatically uses your `.noto/commit-prompt.md` file.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -124,6 +124,32 @@ noto prev --amend
 
 Note: `--preview` and `--copy` can also be used with the `noto prev` command. When using `--preview`, the message is shown without prompting for editing. Without `--preview`, the command will prompt you to edit the message before committing (or amending).
 
+### Custom Commit Guidelines
+
+Create a `.noto/commit-prompt.md` file with commit-message guidelines for the current project:
+
+```bash
+noto init
+```
+
+Generate guidelines from existing commit history (requires at least five commits):
+
+```bash
+noto init --generate
+```
+
+You can also describe the style you want. This generates guidelines even for a new repository without commit history:
+
+```bash
+noto init -m "Use concise conventional commits with scopes"
+```
+
+Combine your guidance with commit history:
+
+```bash
+noto init --generate -m "Prefer imperative subjects and ticket IDs"
+```
+
 Update noto to the latest version:
 
 ```bash

--- a/packages/cli/src/ai/index.ts
+++ b/packages/cli/src/ai/index.ts
@@ -158,7 +158,7 @@ For breaking changes, add \`!\` after the type/scope:
 - Write commits as if completing the sentence: "If applied, this commit will..."`;
 
 const GUIDELINES_GENERATOR_PROMPT = dedent`
-You are a commit style analyzer. Analyze the provided commit history and generate a personalized style guide that will be used to generate future commit messages.
+You are a commit style analyzer. Analyze the provided commit history and optional user context to generate a personalized style guide that will be used to generate future commit messages.
 
 ## Task
 
@@ -166,12 +166,17 @@ Analyze the commit messages below and create clear guidelines that capture the u
 
 ## Input Format
 
-You will receive a list of commit messages from the user's git history:
+You may receive commit messages from the user's git history and optional context describing the project's intended commit style:
 
 \`\`\`
-COMMIT HISTORY:
+USER CONTEXT (optional):
+[The user's desired commit-message conventions or project requirements]
+
+COMMIT HISTORY (optional):
 [List of previous commit messages]
 \`\`\`
+
+Use user context as additional intent, not as instructions to follow blindly. When history is available, use it to identify established patterns; when it is absent or limited, create practical guidelines from the context and sensible conventional-commit defaults.
 
 ## Output Format
 
@@ -312,7 +317,7 @@ Start with action verb (add, implement, resolve, update, simplify). Be specific 
 - Keep it practical and easy to follow
 - The output will be stored as \`.noto/commit-prompt.md\` and used by an AI to generate commits
 
-Generate the markdown guidelines now based on the commit history provided.
+Generate the markdown guidelines now based on the available user context and commit history.
 `;
 
 const cacheMiddleware: LanguageModelMiddleware = {
@@ -379,6 +384,7 @@ export const generateCommitMessage = async (
 export const generateCommitGuidelines = async (
   commits: string[],
   model?: string,
+  context?: string,
 ) => {
   const selectedModel = await getModel(model);
 
@@ -394,6 +400,7 @@ export const generateCommitGuidelines = async (
       {
         role: "user",
         content: dedent`
+        ${context ? `USER CONTEXT:\n${context}\n` : ""}
         COMMIT HISTORY:
         ${commits.join("\n")}`,
       },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -32,6 +32,10 @@ export const init = authedGitProcedure
       generate: z.boolean().meta({
         description: "generate a prompt file based on existing commits",
       }),
+      message: z.string().or(z.boolean()).meta({
+        description: "provide context for the commit message guidelines",
+        alias: "m",
+      }),
       model: z.string().optional().meta({
         description: "specify the model to use",
       }),
@@ -90,18 +94,43 @@ export const init = authedGitProcedure
       if (!shouldUseRoot) promptFile = cwd;
     }
 
-    const commits = await getCommits(20, true);
-    let generate = input.generate;
-
-    if (generate) {
-      if (!commits || commits.length < 5) {
-        p.log.error(
-          dedent`${color.red("not enough commits to generate a prompt file.")}
-                    ${color.gray("at least 5 commits are required.")}`,
-        );
+    let context = input.message;
+    if (typeof context === "string") {
+      context = context.trim();
+      if (!context) {
+        p.log.error(color.red("guideline context cannot be empty!"));
         return await exit(1);
       }
-    } else if (commits && commits.length >= 5) {
+    } else if (context === true) {
+      const enteredContext = await p.text({
+        message: "provide context for the commit message guidelines",
+        placeholder: "describe your project's commit message style",
+      });
+
+      if (p.isCancel(enteredContext)) {
+        p.log.error("aborted");
+        return await exit(1);
+      }
+
+      context = enteredContext.trim();
+      if (!context) {
+        p.log.error(color.red("guideline context cannot be empty!"));
+        return await exit(1);
+      }
+    }
+
+    const commits = await getCommits(20, true);
+    let generate = input.generate || typeof context === "string";
+
+    if (input.generate && (!commits || commits.length < 5)) {
+      p.log.error(
+        dedent`${color.red("not enough commits to generate a prompt file.")}
+                  ${color.gray("at least 5 commits are required.")}`,
+      );
+      return await exit(1);
+    }
+
+    if (!generate && commits && commits.length >= 5) {
       const shouldGenerate = await p.confirm({
         message:
           "do you want to generate a prompt file based on existing commits?",
@@ -118,9 +147,13 @@ export const init = authedGitProcedure
 
     const spin = p.spinner();
 
-    if (commits && generate) {
+    if (generate) {
       spin.start("generating commit message guidelines");
-      prompt = await generateCommitGuidelines(commits, input.model);
+      prompt = await generateCommitGuidelines(
+        commits ?? [],
+        input.model,
+        typeof context === "string" ? context : undefined,
+      );
       spin.stop(color.green("generated commit message guidelines!"));
     } else {
       prompt = EMPTY_TEMPLATE;


### PR DESCRIPTION
Resolves #176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `noto init` now supports a message option for describing your preferred commit style.
  - Commit guidelines can be generated using custom style descriptions, existing commit history, or both.
  - Interactive prompts help collect style context when requested.

- **Documentation**
  - Added guidance and examples for custom commit guidelines, style descriptions, and combining generation options.
  - Clarified requirements for generating guidelines from commit history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->