### PR TITLE
fix: publish Bun-packed tarball with npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 env:
   NOTO_VERSION: ${{ inputs.version || github.ref_name }}
@@ -36,18 +37,14 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
+          registry-url: "https://registry.npmjs.org"
 
       - run: npx changelogithub
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: oven-sh/setup-bun@v2
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          registry-url: "https://registry.npmjs.org"
 
       - run: bun install
         working-directory: packages/cli
@@ -75,11 +72,11 @@ jobs:
           echo "npm_tag=$NPM_TAG" >> $GITHUB_OUTPUT
           echo "Using npm tag: $NPM_TAG"
 
-      - name: Publish to npm
+      - name: Package and publish to npm
         working-directory: packages/cli
-        run: bun publish --provenance --access public --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
-        env:
-          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          TARBALL="$(bun pm pack --destination "$RUNNER_TEMP" --quiet)"
+          npm publish "$TARBALL" --provenance --access public --tag "${{ steps.determine_npm_tag.outputs.npm_tag }}"
 
   homebrew:
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package release process to use a current Node.js runtime.
  - Published packages now include npm provenance metadata, improving release traceability.
  - Streamlined the packaging and publishing workflow for more consistent releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->